### PR TITLE
Fix Build Issues

### DIFF
--- a/cicd-scripts/app_install.sh
+++ b/cicd-scripts/app_install.sh
@@ -73,9 +73,9 @@ install_dependencies() {
     echo "Installing dependencies..."
     python -m pip install --upgrade -r ./search_gov_crawler/requirements.txt
     echo "Installing Playwright..."
-    python -m pip install --upgrade pytest-playwright playwright
+    #python -m pip install --upgrade pytest-playwright playwright
     playwright install --with-deps
-    playwright install chrome
+    playwright install chrome --force
     deactivate
 }
 

--- a/cicd-scripts/app_install.sh
+++ b/cicd-scripts/app_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../
@@ -73,7 +73,6 @@ install_dependencies() {
     echo "Installing dependencies..."
     python -m pip install --upgrade -r ./search_gov_crawler/requirements.txt
     echo "Installing Playwright..."
-    #python -m pip install --upgrade pytest-playwright playwright
     playwright install --with-deps
     playwright install chrome --force
     deactivate

--- a/cicd-scripts/app_install.sh
+++ b/cicd-scripts/app_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/bin/bash
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../

--- a/cicd-scripts/app_start.sh
+++ b/cicd-scripts/app_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../
@@ -12,8 +12,10 @@ SPIDER_RUN_WITH_UI=false
 # Determine which script to run based on the SPIDER_RUN_WITH_UI flag
 SCRIPT="./cicd-scripts/helpers/run_without_ui.sh"
 if $SPIDER_RUN_WITH_UI; then
-    SCRIPT="./cicd-scripts/helpers/run_with_ui.sh"    
+    SCRIPT="./cicd-scripts/helpers/run_with_ui.sh"
 fi
 
 # Ensure the script exists, is executable, and run it
 ensure_executable "$SCRIPT"
+
+echo "App start completed successfully."

--- a/cicd-scripts/app_start.sh
+++ b/cicd-scripts/app_start.sh
@@ -18,6 +18,7 @@ fi
 # Ensure the script exists, is executable, and run it
 ensure_executable "$SCRIPT"
 
+# check that scheduler is running before exit, it not raise error
 if [[ -n $(pgrep -f "scrapy_scheduler.py") ]]; then
     echo "App start completed successfully."
 else

--- a/cicd-scripts/app_start.sh
+++ b/cicd-scripts/app_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/bin/bash
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../
@@ -18,4 +18,9 @@ fi
 # Ensure the script exists, is executable, and run it
 ensure_executable "$SCRIPT"
 
-echo "App start completed successfully."
+if [[ -n $(pgrep -f "scrapy_scheduler.py") ]]; then
+    echo "App start completed successfully."
+else
+    echo "ERROR: Could not start scrapy_scheduler.py. See log file for details."
+    exit 1
+fi

--- a/cicd-scripts/app_stop.sh
+++ b/cicd-scripts/app_stop.sh
@@ -69,6 +69,7 @@ kill_remaining_scrapy_jobs() {
 remove_nohup_jobs() {
     echo "Removing nohup jobs (python)..."
     pgrep -f "nohup.*python" | xargs --no-run-if-empty kill -SIGINT
+    pgrep -f "scrapy_scheduler" | xargs --no-run-if-empty kill -SIGINT
 }
 
 # Remove cron job entries referencing the given string

--- a/cicd-scripts/app_stop.sh
+++ b/cicd-scripts/app_stop.sh
@@ -3,7 +3,6 @@
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../
 
-sudo chmod +x ./cicd-scripts/helpers/ensure_executable.sh
 source ./cicd-scripts/helpers/ensure_executable.sh
 
 ### FUNCTIONS ###
@@ -19,7 +18,7 @@ remove_venv() {
 # Purge pip cache
 purge_pip_cache() {
     echo "Purging pip cache..."
-    rm -rf ~/.cache/pip /root/.cache/pip
+    rm -rf ~/.cache/pip
 }
 
 # Stop scrapy scheduler if running
@@ -56,7 +55,10 @@ display_remaining_scrapy_processes() {
 # Force kill any remaining scrapy background jobs
 kill_remaining_scrapy_jobs() {
     echo "Force killing remaining scrapy background jobs..."
-    if ps aux | grep -ie [s]crapy | awk '{print $2}' | xargs kill -SIGINT; then
+
+    local SCRAPY_PIDS=$(ps aux | grep -ie [s]crapy | awk '{print $2}')
+    if [ -n "$SCRAPY_PIDS" ]; then
+        echo $SCRAPY_PIDS | xargs kill -SIGINT
         echo "Remaining scrapy jobs killed."
     else
         echo "No remaining scrapy jobs to kill."

--- a/cicd-scripts/app_stop.sh
+++ b/cicd-scripts/app_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../

--- a/cicd-scripts/app_stop.sh
+++ b/cicd-scripts/app_stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/bin/bash
 
 # CD into the current script directory (which != $pwd)
 cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../

--- a/cicd-scripts/helpers/run_without_ui.sh
+++ b/cicd-scripts/helpers/run_without_ui.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+LOG_FILE=/var/log/scrapy_scheduler.log
+START_SCRIPT=search_gov_crawler/scrapy_scheduler.py
+
+source ~/.profile
+
 # Run the script in the background using the virtual environment
-sudo chmod +x ./search_gov_crawler/scrapy_scheduler.py
+sudo chmod +x ./$START_SCRIPT
 
-sudo touch /var/log/scrapy_scheduler.log
-sudo chown -R $(whoami) /var/log/scrapy_scheduler.log
+sudo touch $LOG_FILE
+sudo chown -R $(whoami) $LOG_FILE
 
-nohup bash -c "source ./venv/bin/activate && ./venv/bin/python ./search_gov_crawler/scrapy_scheduler.py" | tee -a /var/log/scrapy_scheduler.log &
+echo PYTHONPATH is $PYTHONPATH
+
+nohup bash -c "source ./venv/bin/activate && ./venv/bin/python ./$START_SCRIPT" >> $LOG_FILE 2>&1 &
 
 echo "Running no UI vesrion of searchgov-spider..."
-
-exit 0

--- a/cicd-scripts/helpers/run_without_ui.sh
+++ b/cicd-scripts/helpers/run_without_ui.sh
@@ -9,3 +9,5 @@ sudo chown -R $(whoami) /var/log/scrapy_scheduler.log
 nohup bash -c "source ./venv/bin/activate && ./venv/bin/python ./search_gov_crawler/scrapy_scheduler.py" | tee -a /var/log/scrapy_scheduler.log &
 
 echo "Running no UI vesrion of searchgov-spider..."
+
+exit 0

--- a/cicd-scripts/helpers/update_pythonpath.sh
+++ b/cicd-scripts/helpers/update_pythonpath.sh
@@ -24,8 +24,6 @@ else
 fi
 
 # Apply changes for the current session
-ensure_executable 
-source $BASHRC_FILE "$BASHRC_FILE"
-export PYTHONPATH=":${CURRENT_DIR}"
+source $BASHRC_FILE
 
 echo "PYTHONPATH changes applied: $PYTHONPATH"

--- a/cicd-scripts/helpers/update_pythonpath.sh
+++ b/cicd-scripts/helpers/update_pythonpath.sh
@@ -3,27 +3,34 @@
 # Define the current directory
 CURRENT_DIR=$(pwd)
 
-# Define the .bashrc file location
-BASHRC_FILE="$HOME/.bashrc"
+# Define the .profile file location.  The .profile is used here because it is sourced
+# for non-interactive shells, which is what the codedeploy agent uses to run things.
+PROFILE=$HOME/.profile
 
-# Check if .bashrc contains an export PYTHONPATH line
-if grep -q "^export PYTHONPATH=" "$BASHRC_FILE"; then
+# Check if .profile contains an export PYTHONPATH line
+if grep -q "^export PYTHONPATH=" "$PROFILE"; then
     # Extract the existing PYTHONPATH line
-    PYTHONPATH_LINE=$(grep "^export PYTHONPATH=" "$BASHRC_FILE")
+    PYTHONPATH_LINE=$(grep "^export PYTHONPATH=" "$PROFILE")
 
     # Construct the updated PYTHONPATH line
-    UPDATED_LINE="export PYTHONPATH=\"$\PYTHONPATH:${CURRENT_DIR}\""
+    UPDATED_LINE="export PYTHONPATH=${CURRENT_DIR}"
 
-    # Update the .bashrc file
-    sed -i "s|^export PYTHONPATH=.*|$UPDATED_LINE|" "$BASHRC_FILE"
+    # Update the .profile file
+    sed -i "s|^export PYTHONPATH=.*|$UPDATED_LINE|" "$PROFILE"
     echo "Updated PYTHONPATH to include the current directory: $CURRENT_DIR"
 else
-    # Add a new export PYTHONPATH line to .bashrc
-    echo "export PYTHONPATH=\"$\PYTHONPATH:${CURRENT_DIR}\"" >> "$BASHRC_FILE"
-    echo "Added new PYTHONPATH to .bashrc including the current directory: $CURRENT_DIR"
+    # Add a new export PYTHONPATH line to .profile
+    echo "export PYTHONPATH=${CURRENT_DIR}\"" >> "$PROFILE"
+    echo "Added new PYTHONPATH to .profile including the current directory: $CURRENT_DIR"
 fi
 
 # Apply changes for the current session
-source $BASHRC_FILE
+source $PROFILE
 
-echo "PYTHONPATH changes applied: $PYTHONPATH"
+# Check that PYTHONPATH has been applied
+if [ -n $PYTHONPATH ]; then
+    echo "PYTHONPATH changes applied: $PYTHONPATH"
+else
+    echo "ERROR: Could not apply PYTHONPATH changes"
+    exit 2
+fi


### PR DESCRIPTION
## Summary
- Purpose of this is to fix build issues found in deployment log:
```
[2025-01-21 21:10:59.371] [d-NQI9CNY3M][stdout]Purging pip cache...
[2025-01-21 21:11:00.462] [d-NQI9CNY3M][stderr]rm: cannot remove '/root/.cache/pip': Permission denied
...
[2025-01-21 21:11:00.483] [d-NQI9CNY3M][stdout]Force killing remaining scrapy background jobs...
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr]
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr]Usage:
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr] kill [options] <pid> [...]
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr]
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr]Options:
[2025-01-21 21:11:00.494] [d-NQI9CNY3M][stderr] <pid> [...]            send signal to every <pid> listed
...
[2025-01-21 21:12:03.302] [d-NQI9CNY3M][stdout]Failed to install browsers
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]Error:
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]╔═════════════════════════════════════════════════════════════════╗
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ ATTENTION: "chrome" is already installed on the system!         ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║                                                                 ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ "chrome" installation is not hermetic; installing newer version ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ requires *removal* of a current installation first.             ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║                                                                 ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ To *uninstall* current version and re-install latest "chrome":  ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║                                                                 ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ - Close all running instances of "chrome", if any               ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ - Use "--force" to install browser:                             ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║                                                                 ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║     playwright install --force chrome                           ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║                                                                 ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]║ <3 Playwright Team                                              ║
[2025-01-21 21:12:03.303] [d-NQI9CNY3M][stdout]╚═════════════════════════════════════════════════════════════════╝
...
[2025-01-21 21:12:03.611] [d-NQI9CNY3M][stdout]Running no UI vesrion of searchgov-spider...
[2025-01-21 21:12:03.762] [d-NQI9CNY3M][stderr]Traceback (most recent call last):
[2025-01-21 21:12:03.763] [d-NQI9CNY3M][stderr]  File "/opt/codedeploy-agent/deployment-root/fdddf7f7-e421-4804-b184-d8ea87a31d80/d-NQI9CNY3M/deployment-archive/./search_gov_crawler/scrapy_scheduler.py", line 21, in <module>
[2025-01-21 21:12:03.763] [d-NQI9CNY3M][stderr]    from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
[2025-01-21 21:12:03.763] [d-NQI9CNY3M][stderr]ModuleNotFoundError: No module named 'search_gov_crawler'

```
* Removed separate pip install of playwright since its not needed.  All requirements should be in requirements.txt file.  Added `--force` option to `playwright install` because there doesn't seem to be a way to lock us to a browser version so might as well have the latest.
* Added check at end of `app_start.sh` to confirm that scheduler is running and if not fail the deployment.
* Removed attempted deletion of `/root/.cache/pip` as we were getting permission denied and (I hope) are not using this cache if it exists.
* Added extra logic to kill functions to make sure they were working properly and stop all processes.
* Changed `PYTHONPATH` from `.bashrc` to `.profile` because `.bashrc` is not sourceable in a non-interactive session, which is what codebuild appears to use.  In `.profile` we can source it in the scripts AND it will be available to us if we log in.  Seems like we still have to source it in each top level hook script but at least it is sourceable.  When I changed things to run as interactive I got some new errors and it kept the
* Changed `tee` to `>>` when running `scrapy_scheduler.py` because `tee` was causing the application logs to be output into the codebuild logs AND the application log file specified. 
* Since we had so many `PYTHONPATH` issues, added a check at the end of this to ensure that it is set and if not the pipeline fails.
  * thought about adding a few more checks like this throughout but decided it wasn't worth it.  We could probably just wait for something to go wrong and add a check there so that things fail the next time.

### Testing
You can see past deployments [here](https://us-east-2.console.aws.amazon.com/codesuite/codedeploy/deployments?region=us-east-2&deployments-meta=eyJmIjp7InRleHQiOiIifSwicyI6e30sIm4iOjUwLCJpIjowfQ).  Or you can try to 

If you want to see this in action you can checkout this branch and do something like this:
```
git commit --allow-empty -m "Trigger Build"
git push
```
I have things temporarily setup so that the staging build will trigger on pushes to this branch.  I will remove that once this mereged (or its possible Ebuka will destroy it as part of some terraform work).

You could try this while nothing is running, try this why something is running, and/or try other scenarios.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
