### PR TITLE
build-fix remove extra quote from new pythonpath

### DIFF
--- a/cicd-scripts/helpers/update_pythonpath.sh
+++ b/cicd-scripts/helpers/update_pythonpath.sh
@@ -20,7 +20,7 @@ if grep -q "^export PYTHONPATH=" "$PROFILE"; then
     echo "Updated PYTHONPATH to include the current directory: $CURRENT_DIR"
 else
     # Add a new export PYTHONPATH line to .profile
-    echo "export PYTHONPATH=${CURRENT_DIR}\"" >> "$PROFILE"
+    echo "export PYTHONPATH=${CURRENT_DIR}" >> "$PROFILE"
     echo "Added new PYTHONPATH to .profile including the current directory: $CURRENT_DIR"
 fi
 


### PR DESCRIPTION
## Summary
- Small fix to remove mismatched quote from PYTHONPATH 

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
