### PR TITLE
SRCH-5823-Scrapy-Depth-Limit

### DIFF
--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -46,6 +46,9 @@ SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 # set to True for BFO
 AJAXCRAWL_ENABLED = True
 
+# setting for how deep we want to go 
+DEPTH_LIMIT = os.environ.get("SPIDER_DEPTH_LIMIT", "3")
+#  
 # crawl in BFO order rather than DFO
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"

--- a/tests/search_gov_spiders/test_full_crawl.py
+++ b/tests/search_gov_spiders/test_full_crawl.py
@@ -35,6 +35,7 @@ def fixture_mock_scrapy_settings(monkeypatch):
     settings.set("HTTPCACHE_DBM_MODULE", "dbm.dumb")
     settings.set("HTTPCACHE_DIR", Path(__file__).parent.joinpath("scrapy_httpcache"))
     settings.set("HTTPCACHE_STORAGE", "scrapy.extensions.httpcache.DbmCacheStorage")
+    settings.set("DEPTH_LIMIT", 0)
 
     # Ensures cache does not change, set to False if you need to update or replace cache files
     settings.set("HTTPCACHE_IGNORE_MISSING", True)


### PR DESCRIPTION
## Summary
Added the DEPTH_LIMIT of 3 to spider settings to limit the amount of urls scraped for first pass. 
Currently tests are failing. Going to edit tests to see if depth limit is set it should expect a lower number . 

Needs the ansible playbook PR to set the DEPTH_LIMIT var. But a default is provided here. 

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
