### PR TITLE
SRCH-5827-Additional-Validation

### DIFF
--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
@@ -43,9 +43,9 @@ class CrawlSite:
                 raise TypeError(msg)
         
         # validate output_target values
-        valid_output_targets = ("endpoint", "elastic")
+        valid_output_targets = {"endpoint", "elastic"}
         if self.output_target not in valid_output_targets:
-            msg = f"Invalid output_target value {self.output_target}!  Must be one of {valid_output_targets}"
+            msg = f"Invalid output_target value {self.output_target}! Must be one of {valid_output_targets}"
             raise TypeError(msg)
 
     def to_dict(self, *, exclude: tuple = ()) -> dict:

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
@@ -41,6 +41,12 @@ class CrawlSite:
                     f"Invalid type! Field {field.name} with value {getattr(self, field.name)} must be type {field.type}"
                 )
                 raise TypeError(msg)
+        
+        # validate output_target values
+        valid_output_targets = ("endpoint", "elastic")
+        if self.output_target not in valid_output_targets:
+            msg = f"Invalid output_target value {self.output_target}!  Must be one of {valid_output_targets}"
+            raise TypeError(msg)
 
     def to_dict(self, *, exclude: tuple = ()) -> dict:
         """Helper method to return dataclass as dictionary.  Exclude fields listed in exclude arg."""

--- a/tests/search_gov_spiders/test_crawl_sites.py
+++ b/tests/search_gov_spiders/test_crawl_sites.py
@@ -72,6 +72,20 @@ def test_invalid_crawl_site_wrong_type(base_crawl_site_args, field, new_value, e
     with pytest.raises(TypeError, match=match):
         CrawlSite(**test_args)
 
+@pytest.mark.parametrize(
+    ("field", "new_value", "expected_type"),
+    [
+        ("output_target", "index", {"endpoint", "elastic"}),
+    ],
+)
+def test_invalid_crawl_site_output_target(base_crawl_site_args, field, new_value, expected_type):
+    test_args = base_crawl_site_args | {"schedule": "* * * * *"}
+    test_args[field] = new_value
+
+    match = f"Invalid output_target value {new_value}! Must be one of {expected_type}"
+    with pytest.raises(TypeError, match=match):
+        CrawlSite(**test_args)
+
 
 def test_valid_crawl_sites(base_crawl_site_args):
     cs = CrawlSites([CrawlSite(**base_crawl_site_args)])

--- a/tests/search_gov_spiders/test_crawl_sites.py
+++ b/tests/search_gov_spiders/test_crawl_sites.py
@@ -79,8 +79,7 @@ def test_invalid_crawl_site_wrong_type(base_crawl_site_args, field, new_value, e
     ],
 )
 def test_invalid_crawl_site_output_target(base_crawl_site_args, field, new_value, expected_type):
-    test_args = base_crawl_site_args | {"schedule": "* * * * *"}
-    test_args[field] = new_value
+    test_args = base_crawl_site_args | {field: new_value}
 
     match = f"Invalid output_target value {new_value}! Must be one of {expected_type}"
     with pytest.raises(TypeError, match=match):


### PR DESCRIPTION
## Summary
**Built on PR 87**
Added the field "output_target" to the import_pylist.py file with value "endpoint". All of the domains grabbed from the plist are scrutiny domains that we want to put directly into elastic search. Values from Bing will have a target of "elastic" 

This goes through the rest of the code and takes the field through creation of jobs etc. 

Testing; 
- Updated the test found at `pytest tests/search_gov_spiders/test_crawl_sites.py` which should pass
- You can follow the directions to use the (import_pylist script) [https://github.com/GSA-TTS/searchgov-spider/tree/main/search_gov_crawler/search_gov_spiders/utility_files] also written below 
```
$ cd search_gov_crawler/search_gov_spiders/utility_files
$ python import_plist.py --input_file ./scrutiny-2023-06-20.plist
```
The new crawl-sites-production.json should have added output_target to each Json item. 

These might be overkill but here is how I tested
1) Run all the pytests tests
2) Run one crawl: `scrapy crawl domain_spider -a allowed_domains=quotes.toscrape.com -a start_urls="https://quotes.toscrape.com/"`
3) Run the benchmark: `python benchmark.py -f search_gov_spiders/utility_files/crawl-sites-sample.json`
4) Run with scrapyd
```
$ scrapyd
$ scrapyd-deploy local -p search_gov_spiders
$ curl http://localhost:6800/schedule.json -d project=search_gov_spiders -d spider=domain_spider
```

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
