### PR TITLE
Misfire grace time bug

### DIFF
--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -61,7 +61,7 @@ def init_scheduler() -> BackgroundScheduler:
     return BackgroundScheduler(
         jobstores={"memory": MemoryJobStore()},
         executors={"default": ThreadPoolExecutor(max_workers)},
-        job_defaults={"coalesce": True, "max_instances": 1, "misfire_grace_time": True},
+        job_defaults={"coalesce": True, "max_instances": 1, "misfire_grace_time": None},
         timezone="UTC",
     )
 
@@ -141,7 +141,15 @@ def benchmark_from_args(
         "Starting benchmark from args! "
         "allow_query_string=%s allowed_domains=%s starting_urls=%s handle_javascript=%s output_target=%s runtime_offset_seconds=%s"
     )
-    log.info(msg, allow_query_string, allowed_domains, starting_urls, handle_javascript, output_target, runtime_offset_seconds)
+    log.info(
+        msg,
+        allow_query_string,
+        allowed_domains,
+        starting_urls,
+        handle_javascript,
+        output_target,
+        runtime_offset_seconds,
+    )
 
     apscheduler_job_kwargs = {
         "name": "benchmark",

--- a/tests/search_gov_spiders/test_benchmark.py
+++ b/tests/search_gov_spiders/test_benchmark.py
@@ -3,9 +3,7 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-
 import pytest
-from apscheduler.schedulers.blocking import BlockingScheduler
 from freezegun import freeze_time
 
 from search_gov_crawler import scrapy_scheduler
@@ -27,8 +25,14 @@ def test_init_scheduler(caplog, monkeypatch, scrapy_max_workers, expected_val):
     monkeypatch.setattr(os, "cpu_count", lambda: 10)
 
     with caplog.at_level("INFO"):
-        init_scheduler()
+        scheduler = init_scheduler()
 
+    # ensure config does not change without a failure here
+    assert scheduler._job_defaults == {
+        "misfire_grace_time": None,
+        "coalesce": True,
+        "max_instances": 1,
+    }
     assert f"Max workers for schedule set to {expected_val}" in caplog.messages
 
 


### PR DESCRIPTION
## Summary
I started this PR because in `search_gov_crawler/benchmark.py` i noticed that

`job_defaults={"coalesce": True, "max_instances": 1, "misfire_grace_time": True},`
when it should be
`job_defaults={"coalesce": True, "max_instances": 1, "misfire_grace_time": None},`

The `misfire_grace_time` argument allows the jobs to queue and run when slots are open.  The values must be a positive integer or None.  When its True it does not allow jobs to queue, it just runs the first number of jobs and then stops.  See https://apscheduler.readthedocs.io/en/3.x/userguide.html#missed-job-executions for more details.  Seems to me like it should error but, whatever, not my API.  I also added a test that will break if someone changes these configs

I wanted to add the same check for `scrapy_scheduler.py` but it was integrated into `start_scrapy_scheduler` so I moved the schedule initialization into its own function and added a test there as well.  The main difference now is that the benchmark uses a BackgroundScheduler which allows us to exist once all jobs are done while the scrapy scheduler uses a BlockingScheduler which runs until it is killed.  There is also a difference in the default value of SCRAPY_MAX_WORKERS... idk we could change it but it wasn't really in the path of the change I wanted to do here.

### Testing

Using your .env file or other means, set SCRAPY_MAX_WORKERS = 1 to ensure only on job runs at a time.
Update the test file at `tests/search_gov_spiders/crawl-sites-test.json` so that all four have the `"output_target":"csv"`

You should run a benchmark and scrapy_scheduler job to make sure that all jobs run AND they run one at at time.
If you have set SCRAPY_MAX_WORKERS correctly, you should see a message when you start either script like `"Max workers for schedule set to 1"`

For example, benchmark:
`python search_gov_crawler/benchmark.py -f tests/search_gov_spiders/crawl-sites-test.json`

Also, scrapy_scheduler (this follows a schedule which is set to `0,15,30,45 * * * *` so run just before that if possible) :
First use your .env file or other means to set SPIDER_CRAWL_SITES_FILE_NAME to "../../../tests/search_gov_spiders/crawl-sites-test.json" and then:

`python search_gov_crawler/scrapy_scheduler.py`


### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
