### PR TITLE
Increased CICD CodeDeploy timeout

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -13,7 +13,7 @@ permissions:
 hooks:
   AfterInstall:
     - location: cicd-scripts/app_install.sh
-      timeout: 600
+      timeout: 3600
       runas: search
   ApplicationStart:
     - location: cicd-scripts/app_start.sh


### PR DESCRIPTION
## Summary
Our current CICD CodeDeploy pipeline times out while installing python 3.12, so it needs at lease more than 30min

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
