### PR TITLE
SRCH-5850: Improved elasticsearch index/alias management to accommodate the third search engine

### DIFF
--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -39,6 +39,7 @@ from pythonjsonlogger.json import JsonFormatter
 from search_gov_crawler import scrapy_scheduler
 from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
 from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSites
+from search_gov_crawler.elasticsearch.es_batch_upload import SearchGovElasticsearch
 
 load_dotenv()
 
@@ -121,7 +122,7 @@ def benchmark_from_file(input_file: Path, runtime_offset_seconds: int):
             **crawl_site.to_dict(exclude=("schedule",)),
         )
         scheduler.add_job(**apscheduler_job, jobstore="memory")
-
+    SearchGovElasticsearch.create_index = True
     scheduler.start()
     time.sleep(runtime_offset_seconds + 2)
     scheduler.shutdown()  # this will wait until all jobs are finished
@@ -164,7 +165,7 @@ def benchmark_from_args(
     scheduler = init_scheduler()
     apscheduler_job = create_apscheduler_job(**apscheduler_job_kwargs)
     scheduler.add_job(**apscheduler_job, jobstore="memory")
-
+    SearchGovElasticsearch.create_index = True
     scheduler.start()
     time.sleep(runtime_offset_seconds + 2)
     scheduler.shutdown()  # wait until all jobs are finished

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -21,6 +21,7 @@ from pythonjsonlogger.json import JsonFormatter
 
 from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
 from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSites
+from search_gov_crawler.elasticsearch.es_batch_upload import SearchGovElasticsearch
 
 load_dotenv()
 
@@ -121,6 +122,7 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     for apscheduler_job in apscheduler_jobs:
         scheduler.add_job(**apscheduler_job, jobstore="memory")
 
+    SearchGovElasticsearch.create_index = True
     # Run Scheduler
     scheduler.start()
 


### PR DESCRIPTION
Added more flexibility around elasticsearch index checking/creating/modifying, so it is more compatible with the third search engine option. Once the third search engine is ready we will only need to change two environment variables, eg:
```
SPIDER_ES_INDEX_NAME="spider-production-i14y-documents..."
SPIDER_ES_INDEX_ALIAS=""
```

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
