### PR TITLE
SRCH-5852 On Disk Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,6 @@ cython_debug/
 .scrapy/
 scrapy_urls/
 dbs/
+jobs/
 
 .DS_Store

--- a/search_gov_crawler/search_gov_spiders/extensions/on_disk_queue.py
+++ b/search_gov_crawler/search_gov_spiders/extensions/on_disk_queue.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+from typing import Self
+
+from scrapy.crawler import Crawler
+from scrapy.exceptions import NotConfigured
+from scrapy.signals import spider_closed
+from scrapy.spiders import Spider
+
+
+class OnDiskSchedulerQueue:
+    """Custom scrapy extension that helps clean up the on-disk scheduler queue directory when a spider is finished"""
+
+    setting_key: str = "JOBDIR"
+
+    def remove_directory(self, directory: Path) -> None:
+        """Recusrively remove a directory and contents"""
+
+        for item in directory.iterdir():
+            if item.is_dir():
+                self.remove_directory(item)
+            else:
+                item.unlink()
+
+        directory.rmdir()
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler) -> Self:
+        """
+        Required extension method that checks for configuration and connects extension methons to signals
+        """
+        if not crawler.settings.get(cls.setting_key):
+            msg = f"OnDiskSchedulerQueue extension is listed in settings.EXTENSIONS but {cls.setting_key} is not set."
+            raise NotConfigured(msg)
+
+        ext = cls()
+        crawler.signals.connect(ext.spider_closed, signal=spider_closed)
+        return ext
+
+    def spider_closed(self, spider: Spider) -> None:
+        """Clean up jobs directory when spider is finished"""
+
+        spider_log = logging.getLogger(spider.name)
+        job_dir = spider.settings.get(self.setting_key)
+        self.remove_directory(Path(job_dir))
+        spider_log.info("Removed %s %s at end of spider.", self.setting_key, job_dir)

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -57,7 +57,7 @@ DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 
-# use on-disk job queue
+# Enable on-disk job queue using pid and start time as unique name
 JOBDIR = f"jobs/{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}"
 SCHEDULER_DEBUG = True
 
@@ -78,6 +78,7 @@ DOWNLOADER_MIDDLEWARES = {
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
 EXTENSIONS = {
     "search_gov_spiders.extensions.json_logging.JsonLogging": -1,
+    "search_gov_spiders.extensions.on_disk_queue.OnDiskSchedulerQueue": 500,
     "spidermon.contrib.scrapy.extensions.Spidermon": 600,
 }
 
@@ -106,7 +107,7 @@ TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 date_time = spider_start.isoformat()
 body_html_template = Path(__file__).parent / "actions" / "results.jinja"
 
-SPIDERMON_ENABLED = os.environ.get("SPIDERMON_ENABLED", "True")
+SPIDERMON_ENABLED = os.environ.get("SPIDERMON_ENABLED", "False")
 SPIDERMON_MIN_ITEMS = 1000
 SPIDERMON_TIME_INTERVAL = 1  # time is in seconds
 SPIDERMON_ITEM_COUNT_INCREASE = 100

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -8,7 +8,10 @@
 #     https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
 import os
-from datetime import datetime
+from datetime import UTC, datetime
+from pathlib import Path
+
+spider_start = datetime.now(tz=UTC)
 
 # Settings for logging and json logging
 LOG_ENABLED = False
@@ -46,13 +49,17 @@ SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 # set to True for BFO
 AJAXCRAWL_ENABLED = True
 
-# setting for how deep we want to go 
+# setting for how deep we want to go
 DEPTH_LIMIT = os.environ.get("SPIDER_DEPTH_LIMIT", "3")
-#  
+
 # crawl in BFO order rather than DFO
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
+
+# use on-disk job queue
+JOBDIR = f"jobs/{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}"
+SCHEDULER_DEBUG = True
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
@@ -96,12 +103,10 @@ REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 
 # SPIDERMON SETTINGS
-now = datetime.now()
-date_time = now.today().isoformat()
-dirname = os.path.dirname(__file__)
-body_html_template = os.path.join(dirname, "actions", "results.jinja")
+date_time = spider_start.isoformat()
+body_html_template = Path(__file__).parent / "actions" / "results.jinja"
 
-SPIDERMON_ENABLED = os.environ.get("SPIDERMON_ENABLED", "False")
+SPIDERMON_ENABLED = os.environ.get("SPIDERMON_ENABLED", "True")
 SPIDERMON_MIN_ITEMS = 1000
 SPIDERMON_TIME_INTERVAL = 1  # time is in seconds
 SPIDERMON_ITEM_COUNT_INCREASE = 100

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -58,7 +58,8 @@ SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 
 # Enable on-disk job queue using pid and start time as unique name
-JOBDIR = f"jobs/{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}"
+# https://docs.scrapy.org/en/latest/topics/jobs.html
+JOBDIR = str(Path(__file__).parent.parent / "jobs" / f"{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}")
 SCHEDULER_DEBUG = True
 
 # Enable or disable spider middlewares

--- a/tests/search_gov_spiders/test_full_crawl.py
+++ b/tests/search_gov_spiders/test_full_crawl.py
@@ -27,10 +27,8 @@ def fixture_mock_scrapy_settings(monkeypatch):
         "DOWNLOADER_MIDDLEWARES",
         {f"search_gov_crawler.{k}": v for k, v in dict(settings.get("DOWNLOADER_MIDDLEWARES").attributes).items()},
     )
-    settings.set(
-        "EXTENSIONS",
-        {k: v for k, v in dict(settings.get("EXTENSIONS").attributes).items() if "json_logging" not in k},
-    )
+    settings.set("EXTENSIONS", {})
+    settings.set("JOBDIR", None)
     settings.set("HTTPCACHE_ENABLED", True)
     settings.set("HTTPCACHE_DBM_MODULE", "dbm.dumb")
     settings.set("HTTPCACHE_DIR", Path(__file__).parent.joinpath("scrapy_httpcache"))


### PR DESCRIPTION
## Summary
- This implements the scrapy on-disk scheduler queue https://docs.scrapy.org/en/latest/topics/jobs.html#topics-jobs which allows us to store the queue of pending requests on disk rather than in memory and thus reducing our memory consumption and increasing stability.  We are not going to use this as a "persistent" store as discussed in the docs, it should be cleaned up on spider close and will not be used to restart a spider where it stopped at this time.
- I updated the settings.py file to enable this functionality and wrote a quick extension that cleans up the queue directory when the spider is finished.  For the folder name I chose the pid (since we are using it elsewhere) and the start time to uniquely identify the folder.
- Also, I updated the json logging to include a few more recent arguments.  When a spider logs something, that log message will now also include the `output_target` as well as a few other spider related fields.
- Finally I added new tests and adjusted existing tests so that they work with the new configuration.

### Testing
* Run a scrape job using any method (scrapy crawl / benchmark / scrapy_scheduler) and any output target.
* During the run navigate to `search_gov_crawler/jobs` and see a run specific folder containing files related to the queue.
  * If you start multiple scrapy jobs using benchmark or scrapy scheduler, each job gets its own folder.
* Once the spider(s) finishes, the run specific folder is removed.
  * This removal should happen if the spider stops for any reason including finishing the scrape, stopping due to hitting a timeout constraint, or receiving a `ctrl-C` during the run.
  * It will not get cleaned up if the process receives a kill -9 signal but since the process is immediately stopped in that case we would need another processing to come along and clean it up.  I am thinking we can address this is it becomes a problem with a cron job or something.  

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
