### PR TITLE
SRCH-5855 Prod Errors

### DIFF
--- a/search_gov_crawler/search_gov_spiders/helpers/encoding.py
+++ b/search_gov_crawler/search_gov_spiders/helpers/encoding.py
@@ -1,28 +1,34 @@
+import logging
+import os
 
 import cchardet  # Faster and more reliable character encoding detection than chardet
-import logging
 
 # Needs muting to avoid its debug mode
-logging.getLogger("cchardet").addHandler(logging.NullHandler())
+logging.getLogger("cchardet").setLevel("INFO")
+
 
 def detect_encoding(data: bytes) -> str | None:
     """Detect the encoding of the given byte string."""
     detection_result = cchardet.detect(data)
     encoding = detection_result.get("encoding")
-    
+
+    # VISCII is not fully supported by python but can use cp1258
+    if str(encoding).upper() == "VISCII":
+        return "cp1258"
+
     return encoding if encoding else None
+
 
 def decode_http_response(response_bytes: bytes) -> str:
     """Decode an HTTP response, using the detected encoding or the response's default encoding."""
     try:
-        decoded_str = response_bytes.decode("utf-8")
-        return decoded_str
+        decoded_response = response_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        pass
+        detected_encoding = detect_encoding(response_bytes)
 
-    detected_encoding = detect_encoding(response_bytes)
-    
-    try:
-        return response_bytes.decode(detected_encoding)
-    except (UnicodeDecodeError, TypeError):
-        return str(response_bytes)
+        try:
+            decoded_response = response_bytes.decode(detected_encoding)
+        except (UnicodeDecodeError, TypeError):
+            decoded_response = str(response_bytes)
+
+    return decoded_response

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites-production-scrutiny.json
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites-production-scrutiny.json
@@ -72,15 +72,6 @@
         "starting_urls": "https://www.mynavyhr.navy.mil/"
     },
     {
-        "name": "NIH Diversity",
-        "allow_query_string": false,
-        "allowed_domains": "diversity.nih.gov",
-        "handle_javascript": false,
-        "schedule": "30 09 * * MON",
-        "output_target": "endpoint",
-        "starting_urls": "https://diversity.nih.gov/"
-    },
-    {
         "name": "NIH LRP",
         "allow_query_string": false,
         "allowed_domains": "lrp.nih.gov",

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites-production.json
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites-production.json
@@ -72,15 +72,6 @@
         "starting_urls": "https://www.mynavyhr.navy.mil/"
     },
     {
-        "name": "NIH Diversity",
-        "allow_query_string": false,
-        "allowed_domains": "diversity.nih.gov",
-        "handle_javascript": false,
-        "schedule": "30 09 * * MON",
-        "output_target": "endpoint",
-        "starting_urls": "https://diversity.nih.gov/"
-    },
-    {
         "name": "NIH LRP",
         "allow_query_string": false,
         "allowed_domains": "lrp.nih.gov",

--- a/search_gov_crawler/search_gov_spiders/utility_files/import_plist.py
+++ b/search_gov_crawler/search_gov_spiders/utility_files/import_plist.py
@@ -11,7 +11,8 @@ FILTER_IDS = (
     "20220411-163415",  # US Committee on the Marine Transportation System
     "20220712-164738",  # NASA James Webb Space Telescope
     "20190619-065717",  # NRCS WCC portal
-    "20220615-165843",  # "NOAA Coastwatch Caribbean
+    "20220615-165843",  # NOAA Coastwatch Caribbean
+    "20220804-184649",  # NIH Diversity
 )
 
 
@@ -97,7 +98,7 @@ def convert_plist_to_json(input_file: str, output_file: str, write_full_output: 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process plist files from scrutiny.")
     parser.add_argument("--input_file", type=str, help="path to input file")
-    parser.add_argument("--output_file", type=str, default="crawl-sites-production.json", help="name of file")
+    parser.add_argument("--output_file", type=str, default="crawl-sites-production-scrutiny.json", help="name of file")
     parser.add_argument("--full_output", help="Also output the full json file", action="store_true")
     args = parser.parse_args()
 

--- a/tests/search_gov_spiders/test_crawl_sites.py
+++ b/tests/search_gov_spiders/test_crawl_sites.py
@@ -49,7 +49,7 @@ def test_invalid_crawl_site_missing_field(fields, base_crawl_site_args):
     for field in fields:
         test_args[field] = None
 
-    match = f"All CrawlSite fields are required!  Add values for {",".join(fields)}"
+    match = f"All CrawlSite fields are required!  Add values for {','.join(fields)}"
     with pytest.raises(TypeError, match=match):
         CrawlSite(**test_args)
 
@@ -71,6 +71,7 @@ def test_invalid_crawl_site_wrong_type(base_crawl_site_args, field, new_value, e
     match = f"Invalid type! Field {field} with value {new_value} must be type {expected_type}"
     with pytest.raises(TypeError, match=match):
         CrawlSite(**test_args)
+
 
 @pytest.mark.parametrize(
     ("field", "new_value", "expected_type"),
@@ -118,17 +119,24 @@ def test_invalid_crawl_sites_duplicates(base_crawl_site_args):
         CrawlSites([CrawlSite(**base_crawl_site_args), CrawlSite(**base_crawl_site_args)])
 
 
-def test_crawl_sites_file_is_valid():
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "crawl-sites-sample.json",
+        "crawl-sites-production.json",
+        "crawl-sites-production-scrutiny.json",
+    ],
+)
+def test_crawl_sites_file_is_valid(file_name):
     """
     Read in the actual crawl-sites-sample.json file and instantiate as a CrawlSites class.  This will run all built-in
     validations and hopefully let you know if the file is invalid prior to attempting to run it in the scheduler.
     Additionally, we are assuming that there is at least one scheduled job in the file.
     """
 
-    for file_name in ["crawl-sites-sample", "crawl-sites-production"]:
-        crawl_sites_file = (
-            Path(__file__).parent.parent.parent / f"search_gov_crawler/search_gov_spiders/utility_files/{file_name}.json"
-        )
+    crawl_sites_file = (
+        Path(__file__).parent.parent.parent / f"search_gov_crawler/search_gov_spiders/utility_files/{file_name}"
+    )
 
-        cs = CrawlSites.from_file(file=crawl_sites_file)
-        assert len(list(cs.scheduled())) > 0
+    cs = CrawlSites.from_file(file=crawl_sites_file)
+    assert len(list(cs.scheduled())) > 0


### PR DESCRIPTION
## Summary
- Addresses two recurring errors in prod:
  - Removes `diversity.nih.gov` from the scrutiny lists
  - Adds support for VISCII encoding
    - For the VISCII support, it appears that python does not support this but does support both unicode and cp1258 which according to wikipedia https://en.wikipedia.org/wiki/VISCII are close but may be missing some characters.  I guess if we actually try to index this we may miss some characters.  This is an "endpoint" domain however so we are just passing the URL to search anyway.  I originally had it defaulting to unicode in this case but decided on a Vietnamese-specific code page.  If we run into more issues with indexing this content I think we should revisit. 

### Testing
- For the domain removal just verify that the domain has been remove from the apropriate lists
- For the VISCII error: the page in question is https://www.accessdata.fda.gov/CMS_IA/importalert_401.html.
  - If you run `scrapy crawl domain_spider -a allowed_domains=accessdata.fda.gov -a start_urls=https://www.accessdata.fda.gov/CMS_IA/importalert_401.html -a output_target=endpoint` you should not see an error like the one in prod.
  - If you were to comment out the lines in `detect_encoding` that I have added you will see the prod error.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
