### PR TITLE
SRCH-5861 Add config for newspaper to limit unnecessay actions

### DIFF
--- a/search_gov_crawler/elasticsearch/convert_html_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_html_i14y.py
@@ -1,26 +1,30 @@
-import os
 import hashlib
-import newspaper
-import tldextract
-from datetime import datetime, timezone
+import os
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 
-import search_gov_crawler.search_gov_spiders.helpers.content as content
+import newspaper
+import tldextract
+
 from search_gov_crawler.elasticsearch.parse_html_scrapy import convert_html_scrapy
+from search_gov_crawler.search_gov_spiders.helpers import content
 
+# fmt: off
+ALLOWED_LANGUAGE_CODE = (
+    "ar", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es", "et", "fa", "fr",
+    "he", "hi", "hr", "ht", "hu", "hy", "id", "it", "ja", "km", "ko", "lt", "lv",
+    "mk", "nl", "pl", "ps", "pt", "ro", "ru", "sk", "so", "sq", "sr", "sw", "th",
+    "tr", "uk", "ur", "uz", "vi", "zh",
+)
+# fmt: on
 
-ALLOWED_LANGUAGE_CODE = {
-    lang: True for lang in [
-        "ar", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es", "et", "fa", "fr",
-        "he", "hi", "hr", "ht", "hu", "hy", "id", "it", "ja", "km", "ko", "lt", "lv",
-        "mk", "nl", "pl", "ps", "pt", "ro", "ru", "sk", "so", "sq", "sr", "sw", "th",
-        "tr", "uk", "ur", "uz", "vi", "zh"
-    ]
-}
 
 def convert_html(html_content: str, url: str):
     """Extracts and processes article content from HTML using newspaper4k."""
-    article = newspaper.Article(url=url)
+    config = newspaper.Config()
+    config.fetch_images = False  # we are not using images, do not fetch!
+    config.clean_article_html = False  # we are not using article_html, so don't clean it!
+    article = newspaper.Article(url=url, config=config)
     article.download(input_html=html_content)
     article.parse()
     article.nlp()
@@ -30,7 +34,7 @@ def convert_html(html_content: str, url: str):
 
     if not main_content:
         return None
-        
+
     title = article.title or article.meta_site_name or article_backup["title"] or None
     description = article.meta_description or article.summary or article_backup["description"] or None
 
@@ -43,7 +47,7 @@ def convert_html(html_content: str, url: str):
     language = article.meta_lang or article_backup["language"]
     valid_language = f"_{language}" if language in ALLOWED_LANGUAGE_CODE else ""
 
-    i14y_doc = {
+    return {
         "audience": article_backup["audience"],
         "changed": article_backup["changed"],
         "click_count": None,
@@ -69,31 +73,34 @@ def convert_html(html_content: str, url: str):
         "basename": basename,
         "extension": extension or None,
         "url_path": get_url_path(url),
-        "domain_name": get_domain_name(url)
+        "domain_name": get_domain_name(url),
     }
 
-    return i14y_doc
 
 def get_url_path(url: str) -> str:
     """Extracts the path from a URL."""
     return urlparse(url).path
+
 
 def get_base_extension(url: str) -> tuple[str, str]:
     """Extracts the basename and file extension from a URL."""
     basename, extension = os.path.splitext(os.path.basename(urlparse(url).path))
     return basename, extension
 
+
 def current_utc_iso() -> str:
     """Returns the current UTC timestamp in ISO format."""
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds") + "Z"
+    return datetime.now(tz=UTC).isoformat(timespec="milliseconds") + "Z"
+
 
 def generate_url_sha256(url: str) -> str:
     """Generates a SHA-256 hash for a given URL."""
     return hashlib.sha256(url.encode()).hexdigest()
 
+
 def get_domain_name(url: str) -> str:
     """Extracts the domain from a URL, removing www and ensuring consistency."""
-    parsed = urlparse(url if url.startswith(('http://', 'https://')) else f'https://{url}')
+    parsed = urlparse(url if url.startswith(("http://", "https://")) else f"https://{url}")
     extracted = tldextract.extract(parsed.netloc)
-    domain = f"{extracted.subdomain}.{extracted.domain}.{extracted.suffix}".lstrip('.').replace("www.", "")
+    domain = f"{extracted.subdomain}.{extracted.domain}.{extracted.suffix}".lstrip(".").replace("www.", "")
     return domain


### PR DESCRIPTION
## Summary
In dev i have been seeing a lot of messages like these:
`error not enough image data while fetching: https://www.usgs.gov/themes/custom/usgs_tantalum/favicon.ico`
`error while fetching: https://home.army.mil/imcom-europe/5915/4824/7604/Box_MWR.jpg`

They all stem from the `newspaper.image_extractors` module.  That got me thinking, why are we trying to fetch these?
In the [configuration settings](https://newspaper4k.readthedocs.io/en/latest/user_guide/api_reference.html#configuration) there is an option to turn off this behavior.

Looking through the rest of the options, I think there are a few we could try eventually to reduce cpu or whatever but one that stood out is the `clean_article_html` option.  We are not using the output of this field so we don't need to clean it.

I looked through the code for both of these options and don't think this will affect us.  The real change in this PR is:
```python
    config = newspaper.Config()
    config.fetch_images = False  # we are not using images, do not fetch!
    config.clean_article_html = False  # we are not using article_html, so don't clean it!
    article = newspaper.Article(url=url, config=config)
```


### Testing
On main, run a scrape that generates these errors:
`scrapy crawl domain_spider -a allowed_domains=ed.gov -a start_urls=https://www.ed.gov/ -a output_target=elasticsearch`

in a few minutes you will see the errors - **don't wait for this to finish, its long** - i would wait until you see one message about writing to elasticearch and then ctrl-C. 

We also want to make sure we are not changing the content with this change.  Inspect a document, for instance if you followed the instructions above you probably have a document matching this search:
```
GET /i14y-documents-spider/_search
{
  "query": {
   "match": {
     "path.keyword": "https://aefla.ed.gov/state-grants"
   }
  }
}
```
capture the record, or at least the _source.

Now switch back to this branch, clear out your index
`curl -X DELETE http://localhost:9200/i14y-documents-spider`

and run the same scrapy crawl again.  You should not see any image messages.  You can again cancel when you see at least one load to elasticsearch and then go run the same elasticsearch query and compare the results -- they should be the same except for dates like created_at and updated_at.  I chose this document because it has a thumbnail URL, the only image-related item on the document. 

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
