### PR TITLE
SRCH-5864 Enhance logging ES Errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,13 @@ disable= [
     "missing-function-docstring",
     "too-few-public-methods",
     "too-many-arguments",
-    "too-many-positional-arguments"
+    "too-many-positional-arguments",
+    "too-many-instance-attributes"
+]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "module"
+filterwarnings = [
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning"
 ]

--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -5,15 +5,15 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from urllib.parse import urlparse
 
-from elasticsearch import Elasticsearch, helpers
+from elasticsearch import Elasticsearch, helpers  # pylint: disable=wrong-import-order
+from pythonjsonlogger.json import JsonFormatter
 from scrapy.spiders import Spider
 
 from search_gov_crawler.elasticsearch.convert_html_i14y import convert_html
-from pythonjsonlogger.json import JsonFormatter
 from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
 
 # limit excess INFO messages from elasticsearch that are not tied to a spider
-logging.getLogger("elastic_transport.transport").setLevel("ERROR")
+logging.getLogger("elastic_transport").setLevel("ERROR")
 
 logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
 logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
@@ -84,8 +84,8 @@ class SearchGovElasticsearch:
                     ssl_show_warn=False,
                     basic_auth=(self._env_es_username, self._env_es_password),
                 )
-            except Exception as e:
-                log.error(f"Couldn't create an elasticsearch client: {str(e)}")
+            except Exception:  # pylint: disable=broad-except
+                log.exception("Couldn't create an elasticsearch client")
         return self._es_client
 
     def create_index_if_not_exists(self):
@@ -100,9 +100,9 @@ class SearchGovElasticsearch:
                     "settings": {"index": {"number_of_shards": 6, "number_of_replicas": 1}},
                 }
                 es_client.indices.create(index=index_name, body=index_settings)
-                log.info(f"Index '{index_name}' created successfully.")
-        except Exception as e:
-            log.error(f"General error creating/updating index: {str(e)}")
+                log.info("Index '%s' created successfully.", index_name)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("General error creating/updating index")
 
     def _create_actions(self, docs: list[dict[Any, Any]]) -> list[dict[str, Any]]:
         """
@@ -118,9 +118,12 @@ class SearchGovElasticsearch:
         def _bulk_upload():
             try:
                 actions = self._create_actions(docs)
-                success, _ = helpers.bulk(self._get_client(), actions)
-                spider.logger.info("Loaded %s records to Elasticsearch!", success)
-            except Exception as e:
-                spider.logger.error(f"Error in bulk upload: {str(e)}")
+                success, errors = helpers.bulk(self._get_client(), actions, raise_on_error=False)
+                if success:
+                    spider.logger.info("Loaded %s records to Elasticsearch!", success)
+                if errors:
+                    spider.logger.error("Error in bulk upload: %s document(s) failed to index: %s", len(errors), errors)
+            except Exception:  # pylint: disable=broad-except
+                spider.logger.exception("Error in bulk upload")
 
         await loop.run_in_executor(self._executor, _bulk_upload)

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -100,8 +100,6 @@ AUTOTHROTTLE_ENABLED = False
 HTTPCACHE_ENABLED = False
 HTTPCACHE_DIR = "httpcache"
 
-# Set settings whose default value is deprecated to a future-proof value
-REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 
 # SPIDERMON SETTINGS

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -21,6 +21,7 @@ html_content = """
     </html>
 """
 
+
 @pytest.fixture
 def sample_spider():
     """Fixture for a mock spider with a logger."""
@@ -30,16 +31,21 @@ def sample_spider():
 
     return SpiderMock()
 
+
 # Mock environment variables
 @pytest.fixture(autouse=True)
 def search_gov_es():
-    with patch.dict(os.environ, {
-        "ES_HOSTS": "http://localhost:9200",
-        "SPIDER_ES_INDEX_NAME": "test_index",
-        "ES_USER": "test_user",
-        "ES_PASSWORD": "test_password"
-    }):
+    with patch.dict(
+        os.environ,
+        {
+            "ES_HOSTS": "http://localhost:9200",
+            "SPIDER_ES_INDEX_NAME": "test_index",
+            "ES_USER": "test_user",
+            "ES_PASSWORD": "test_password",
+        },
+    ):
         yield SearchGovElasticsearch(batch_size=2)
+
 
 @pytest.fixture
 def mock_es_client():
@@ -49,13 +55,15 @@ def mock_es_client():
     client.indices.create = MagicMock()
     return client
 
+
 # Mock convert_html function
 @pytest.fixture
 def mock_convert_html():
     with patch("search_gov_crawler.elasticsearch.es_batch_upload.convert_html") as mock:
         yield mock
 
-@pytest.fixture
+
+@pytest.fixture()
 def mock_asyncio_loop():
     with patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.get_event_loop") as mock_get_loop:
         mock_loop = asyncio.new_event_loop()
@@ -65,6 +73,7 @@ def mock_asyncio_loop():
             mock_new_loop.return_value = mock_loop
             yield mock_loop
             mock_loop.close()
+
 
 # Test add_to_batch (Corrected)
 @pytest.mark.asyncio(loop_scope="module")
@@ -78,6 +87,7 @@ async def test_add_to_batch(mock_convert_html, sample_spider):
     es_uploader.add_to_batch(html_content, "http://example.com/2", sample_spider)
     assert len(es_uploader._current_batch) == 0
 
+
 @pytest.mark.asyncio(loop_scope="module")
 async def test_batch_upload(mock_convert_html, sample_spider):  # Use pytest-asyncio's event loop
     es_uploader = SearchGovElasticsearch(batch_size=2)
@@ -87,6 +97,7 @@ async def test_batch_upload(mock_convert_html, sample_spider):  # Use pytest-asy
     es_uploader.batch_upload(sample_spider)
     assert len(es_uploader._current_batch) == 0
 
+
 @pytest.mark.asyncio(loop_scope="module")
 async def test_batch_upload_empty(sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
@@ -94,6 +105,7 @@ async def test_batch_upload_empty(sample_spider):
     es_uploader._batch_elasticsearch_upload = MagicMock()
     es_uploader.batch_upload(sample_spider)
     es_uploader._batch_elasticsearch_upload.assert_not_called()  # Ensure it is not called when the batch is empty
+
 
 # Test _batch_elasticsearch_upload
 @pytest.mark.asyncio(loop_scope="module")
@@ -105,6 +117,7 @@ async def test_batch_elasticsearch_upload(mock_convert_html, mock_asyncio_loop, 
     await es_uploader._batch_elasticsearch_upload(docs, mock_asyncio_loop, sample_spider)
     es_uploader._create_actions.assert_called_once()
 
+
 def test_add_to_batch_no_doc(mock_convert_html, sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
     mock_convert_html.return_value = None
@@ -112,21 +125,31 @@ def test_add_to_batch_no_doc(mock_convert_html, sample_spider):
     es_uploader.add_to_batch("<html></html>", "http://example.com/1", sample_spider)
     assert len(es_uploader._current_batch) == 0
 
+
 def test_parse_es_urls_invalid_url():
     es_uploader = SearchGovElasticsearch()
     with pytest.raises(ValueError) as excinfo:
         es_uploader._parse_es_urls("invalid-url")
     assert "Invalid Elasticsearch URL" in str(excinfo.value)
 
+
 def test_parse_es_urls_valid_urls():
     es_uploader = SearchGovElasticsearch()
     hosts = es_uploader._parse_es_urls("http://localhost:9200,https://remotehost:9300")
-    assert hosts == [{"host": "localhost", "port": 9200, "scheme": "http"}, {"host": "remotehost", "port": 9300, "scheme": "https"}]
+    assert hosts == [
+        {"host": "localhost", "port": 9200, "scheme": "http"},
+        {"host": "remotehost", "port": 9300, "scheme": "https"},
+    ]
+
 
 def test_index_exists(mock_es_client, search_gov_es):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client", return_value=mock_es_client):
+    with patch(
+        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+        return_value=mock_es_client,
+    ):
         search_gov_es.create_index_if_not_exists()
         mock_es_client.indices.exists.assert_called_once_with(index="test_index")
+
 
 def test_get_client(search_gov_es, mock_es_client):
     with patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch", return_value=mock_es_client):
@@ -134,23 +157,38 @@ def test_get_client(search_gov_es, mock_es_client):
         assert client is mock_es_client
         assert search_gov_es._es_client is mock_es_client
 
+
 def test_get_client_exception(search_gov_es):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch", side_effect=Exception("Test Exception")), \
-         patch("search_gov_crawler.elasticsearch.es_batch_upload.log") as mock_log:
+    with (
+        patch(
+            "search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch",
+            side_effect=Exception("Test Exception"),
+        ),
+        patch("search_gov_crawler.elasticsearch.es_batch_upload.log") as mock_log,
+    ):
         client = search_gov_es._get_client()
         assert client is None
-        mock_log.error.assert_called_once()
+        mock_log.exception.assert_called_once()
+
 
 def test_create_index_if_not_exists(search_gov_es, mock_es_client):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client", return_value=mock_es_client):
+    with patch(
+        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+        return_value=mock_es_client,
+    ):
         mock_es_client.indices.exists.return_value = False
         search_gov_es.create_index_if_not_exists()
         mock_es_client.indices.create.assert_called_once()
 
+
 def test_create_index_if_exists(search_gov_es, mock_es_client):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client", return_value=mock_es_client):
+    with patch(
+        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+        return_value=mock_es_client,
+    ):
         mock_es_client.indices.exists.return_value = True
         search_gov_es.create_index_if_not_exists()
+
 
 def test_create_actions(search_gov_es):
     docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
@@ -160,11 +198,21 @@ def test_create_actions(search_gov_es):
         {"_index": "test_index", "_id": "2", "_source": {"content": "test2"}},
     ]
 
-@pytest.mark.asyncio
+
+@pytest.mark.asyncio()
 async def test_batch_elasticsearch_upload_error(search_gov_es, sample_spider, mock_es_client):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client", return_value=mock_es_client), \
-         patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.bulk", side_effect=Exception("bulk error")):
+    with (
+        patch(
+            "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+            return_value=mock_es_client,
+        ),
+        patch(
+            "search_gov_crawler.elasticsearch.es_batch_upload.helpers.bulk",
+            return_value=(49, [{"error": "Test Error"}]),
+        ),
+    ):
         docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
         loop = asyncio.get_event_loop()
         await search_gov_es._batch_elasticsearch_upload(docs, loop, sample_spider)
-        sample_spider.logger.error.assert_called_once()
+        sample_spider.logger.error.assert_called_once()  # logged errors from bulk_upload
+        sample_spider.logger.exception.assert_not_called()  # did not log and exception


### PR DESCRIPTION
## Summary
- This PR is meant to address deficiencies in logging when we encounter an error loading data to elasticsearch.  Prior to these change you might see something like `"Failed to load 50 records to Elasticsearch"` as the entire log message -- which doesnt tell you anything about why the error occured!
  - The bulk uploaded was adjusted so that it does not raise an Exception on one of these errors, rather it collects all the errors and returns them.  Then we can check and log all the errors.
  - It can make for some lengthy logs, I considered truncating it past a certain length or aggregating it but ultimately decided that its better have all the information and it doesnt really matter how big the log files are, thats what they are there for.
- I also included a few small changes for ease of use/maintenence:
  - Removed or hid a few warnings that displayed each test run and were not telling us anything important and having lots of warnings we don't care about here makes it harder to notice when there is something new that we actually might care about.
    - Configured pytest default fixture loop scope for asyncio tests
    - Ignored DeprecationWarnings from third party libraries
    - Removed deprecated scrapy setting REQUEST_FINGERPRINTER_IMPLEMENTATION
  - Updated pylint config and es_batch_upload.py to be more in compliance with pylint.
    - For the too broad exceptions issues, normally i would like to make those more specific but given how many different types of errors can come out of the es client init, I think it would have decreased readability to include them all.


### Testing
- To see the new error messages, pull up your local kibana, go to "Stack Management --> Index Managment" choose the index and select the option to Freeze it.  Now, run a scrape, e.g. `scrapy crawl domain_spider -a allowed_domains=quotes.toscrape.com -a start_urls=https://quotes.toscrape.com -a output_target=elasticsearch`... when it goes to write records to ES you should see logs like `"Error in bulk upload: 50 document(s) failed to index: [{'index': {'_index': 'i14y-documents-spider', '_type': '_doc', '_id': '2123769ed76584bd20d18cd8eeaa3841f3b78bf843e4f820156b934462d9fcc1', 'status': 403, 'error': {'type': 'cluster_block_exception', 'reason': 'index [i14y-documents-spider] blocked by: [FORBIDDEN/8/index write (api)];'}}}, {'index': {'_index': 'i14y-documents-spider', '_type': '_doc', '_id': '1c526ea9b98d76ddcffe03c890e5cf2e0be456404f3e6b44276f644497a85f8a', 'status': 403, 'error': {'type': 'cluster_block_exception', 'reason': 'index [i14y-documents-spider] blocked by: [FORBIDDEN/8/index write (api)];'}}}, ...`.  Now, unfreeze the index and try again, you should see the familiar "Loaded 50 records to Elasticsearch!" message.  Connection errors still raise a normal error.
![image](https://github.com/user-attachments/assets/1fb296f0-5e06-4c73-8ac9-0a47bb36601d)

- Nothing to test with the pylint and testing changes, just that things still work and tests still pass and/or if you have a differing of opinion on how we should handle some of these.  We used to get these warning messages and now we don't:
  - From pytest-asyncio:`PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.`
  - `DeprecationWarning: pkg_resources is deprecated as an API.`
  - `DeprecationWarning: Deprecated call to pkg_resources.declare_namespace('sphinxcontrib')`
  - `DeprecationWarning: Deprecated call to pkg_resources.declare_namespace('zope')`
  - `ScrapyDeprecationWarning: 'REQUEST_FINGERPRINTER_IMPLEMENTATION' is a deprecated setting.`
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
