### PR TITLE
Remove duplicate arg from Benchmark -f

### DIFF
--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -91,8 +91,7 @@ def create_apscheduler_job(
         "func": scrapy_scheduler.run_scrapy_crawl,
         "id": job_name,
         "name": job_name,
-        "next_run_time": datetime.now(tz=UTC)
-        + timedelta(seconds=runtime_offset_seconds),
+        "next_run_time": datetime.now(tz=UTC) + timedelta(seconds=runtime_offset_seconds),
         "args": [
             "domain_spider" if not handle_javascript else "domain_spider_js",
             allow_query_string,
@@ -185,9 +184,7 @@ def benchmark_from_args(
 if __name__ == "__main__":
     no_input_arg = all(arg not in sys.argv for arg in ["-f", "--input_file"])
 
-    parser = argparse.ArgumentParser(
-        description="Run a scrapy schedule or benchmark based on input."
-    )
+    parser = argparse.ArgumentParser(description="Run a scrapy schedule or benchmark based on input.")
     parser.add_argument(
         "-f",
         "--input_file",
@@ -207,14 +204,6 @@ if __name__ == "__main__":
         type=str,
         help="url used to start crawl",
         required=no_input_arg,
-    )
-    parser.add_argument(
-        "-o",
-        "--output_target",
-        type=str,
-        help="Point the output of the crawls to a backend",
-        required=no_input_arg,
-        choices=list(ALLOWED_CONTENT_TYPE_OUTPUT_MAP.keys()),
     )
     parser.add_argument(
         "-o",
@@ -267,6 +256,4 @@ if __name__ == "__main__":
         }
         benchmark_from_args(**benchmark_args)
     else:
-        benchmark_from_file(
-            input_file=Path(args.input_file), runtime_offset_seconds=args.runtime_offset
-        )
+        benchmark_from_file(input_file=Path(args.input_file), runtime_offset_seconds=args.runtime_offset)


### PR DESCRIPTION
## Summary
The output_target argument for benchmark -f was duplicated.  Once starting at line 211 and once starting at line 219, probably a merge conflict issue?  Anyway this means you cannot run `benchmark.py -f`.  This PR fixes that.

The other changes were auto formatting from by editor... more reason to get pylint (or something) in place i guess.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
