### PR TITLE
SRCH-5908 download limit size

### DIFF
--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -44,6 +44,8 @@ CONCURRENT_REQUESTS = 1
 CONCURRENT_REQUESTS_PER_DOMAIN = 1
 DOWNLOAD_DELAY = 1
 
+DOWNLOAD_MAXSIZE = 15728640  # 15MB
+
 # settings for broad crawling
 SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 # set to True for BFO
@@ -59,11 +61,7 @@ SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 
 # Enable on-disk job queue using pid and start time as unique name
 # https://docs.scrapy.org/en/latest/topics/jobs.html
-JOBDIR = str(
-    Path(__file__).parent.parent
-    / "jobs"
-    / f"{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}"
-)
+JOBDIR = str(Path(__file__).parent.parent / "jobs" / f"{os.getpid()}-{spider_start.strftime('%Y%m%d%H%M%S')}")
 SCHEDULER_DEBUG = True
 
 # Enable or disable spider middlewares

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -44,7 +44,8 @@ CONCURRENT_REQUESTS = 1
 CONCURRENT_REQUESTS_PER_DOMAIN = 1
 DOWNLOAD_DELAY = 1
 
-DOWNLOAD_MAXSIZE = 15728640  # 15MB
+# Limit downloads to 15MB
+DOWNLOAD_MAXSIZE = 15728640
 
 # settings for broad crawling
 SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"


### PR DESCRIPTION
## Summary
- Added the 15MB limit for files and html content to download.  It is stopped prior the download started and definitely seems to be an improvement for domains where this happens. It doesn't always help but it seems like it could be one of a few things we do.  Here are some results.  Feel free to try it on some of these domains with and without the setting.
- When the setting is enabled and a download is encountered that is higher than the limit, it logs a WARN message like `Cancelling download of https://www.blm.gov/sites/default/files/docs/2021-04/BLM_WHB_ActivityBook_508_Dr1_031921.pdf: expected response size (15768110) larger than download max size (15728640).`
- The stats are from the scrapy stat collection module that prints at the end of each spider.
- The one time i saw a larger memory usage when applying this setting the number of items also jumped so maybe that accounts for it?
- Seems like an easy constraint we should implement.
- Anyway let me know what you think.  Any additional tests you would like to see? Any concerns.

|Date|Env|Limit|Domain|memusage startup|memusage max|item scraped count|elapsed time seconds|
|-|-|-|-|-|-|-|-|
|14-Mar|prod|1GB|fema.training.gov|119,058,432|223,592,448|256|1067.091126|
|25-Mar|staging|15MB|fema.training.gov|125,165,568|162,799,616|364|1044.291376|
|25-Mar|prod|1GB|eisenhowerlibrary.gov|119,353,344|316,370,944|1407|5362.649439|
|25-Mar|staging|15MB|eisenhowerlibrary.gov|125,526,016|188,510,208|4284|5354.06658|
|25-Mar|prod|1GB|researchfestival.nih.gov|119,513,088|163,528,704|3486|4426.617503|
|25-Mar|staging|15MB|researchfestival.nih.gov|125,472,768|250,527,744|3518|4429.501598|
|25-Mar|prod|1GB|cdfifund.gov|119,734,272|220,565,504|1991|3572.895481|
|25-Mar|staging|15MB|cdfifund.gov|125,177,856|233,934,848|2788|3584.762704|
|25-Mar|prod|1GB|hydrogen.energy.gov|119,566,336|161,624,064|431|1570.048758|
|25-Mar|staging|15MB|hydrogen.energy.gov|125,038,592|163,938,304|1199|1624.64813|
|25-Mar|prod|1GB|bep.gov|119,746,560|161,267,712|158|391.101739|
|25-Mar|staging|15MB|bep.gov|125,026,304|148,520,960|295|392.195788|
|25-Mar|prod|1GB|search.gov|119,533,568|155,598,848|212|305.973423|
|25-Mar|staging|15MB|search.gov|125,231,104|162,439,168|220|307.658754|
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
