### PR TITLE
SRCH-5987 Logging and cache tools

### DIFF
--- a/scripts/cache_tools.py
+++ b/scripts/cache_tools.py
@@ -1,0 +1,74 @@
+import argparse
+from datetime import UTC, datetime
+
+from redis import Redis
+
+from search_gov_crawler.scheduling.redis import get_redis_connection_args
+
+
+def init_redis_client() -> Redis:
+    """Initialize a Redis client using connection arguments from environment variables."""
+    # Create a Redis client with the connection arguments
+    redis_connection_args = get_redis_connection_args()
+    return Redis(**redis_connection_args)
+
+
+def print_headers(key: str, results: list) -> None:
+    """Print the headers for the given key and results."""
+    print("-" * 80)
+    print(f"Key:  {key}")
+    print(f"Jobs: {len(results)}")
+    print("-" * 80)
+
+
+def print_all_jobs(redis: Redis, key: str) -> None:
+    """Print all jobs from the give redis key."""
+    results = redis.hgetall(key)
+    print_headers(key=key, results=results)
+    print(f"{'Job Id':<80}")
+    print("-" * 80)
+    for job_id, _job in results.items():
+        print(f"{job_id.decode('utf-8'):<80}")
+
+
+def print_sorted_set(redis: Redis, key: str, score_title: str, start: int = 0, end: int = -1) -> None:
+    """Get the pending jobs from the Redis job store."""
+    results = redis.zrange(name=key, start=start, end=end, withscores=True)
+
+    print_headers(key=key, results=results)
+    print(f"{'Job Id':<50} {score_title:<30}")
+    print("-" * 80)
+    for job_id, next_run_ts in results:
+        next_run_datetime = datetime.fromtimestamp(next_run_ts, tz=UTC).strftime("%Y-%m-%d %H:%M:%S %Z")
+        print(f"{job_id.decode('utf-8'):<50} {next_run_datetime:<30}")
+
+
+def clear_pending_jobs(redis: Redis, key: str) -> None:
+    """Clear the pending jobs from the Redis job store."""
+    redis.delete(key)
+    print(f"Cleared all pending jobs from key {key}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Redis job store tools")
+    parser.add_argument(
+        "command",
+        type=str,
+        choices=["clear-pending-jobs", "show-all-jobs", "show-pending-jobs", "show-run-times"],
+        help="Command to execute",
+    )
+    args = parser.parse_args()
+
+    redis_client = init_redis_client()
+    match args.command:
+        case "clear-pending-jobs":
+            clear_pending_jobs(redis=redis_client, key="spider.schedule.pending_jobs")
+        case "show-all-jobs":
+            all_jobs_args = {"key": "spider.schedule.jobs"}
+            print_all_jobs(redis=redis_client, **all_jobs_args)
+        case "show-pending-jobs":
+            pending_job_args = {"key": "spider.schedule.pending_jobs", "score_title": "Time Added to Queue"}
+            print_sorted_set(redis=redis_client, **pending_job_args)
+        case "show-run-times":
+            run_time_args = {"key": "spider.schedule.run_times", "score_title": "Next Run Time"}
+            print_sorted_set(redis=redis_client, **run_time_args)

--- a/scripts/cache_tools.py
+++ b/scripts/cache_tools.py
@@ -1,3 +1,17 @@
+"""
+This script provides functionality to view and clear jobs in the Redis job store.
+It includes commands to show all jobs, show pending jobs, show run times,
+and clear pending jobs.
+
+Usage:
+    python cache_tools.py <command>
+    where <command> is one of:
+        - clear-pending-jobs: Clear all pending jobs from the Redis job store.
+        - show-all-jobs: Show all jobs in the Redis job store.
+        - show-pending-jobs: Show pending jobs in the Redis job store.
+        - show-run-times: Show run times of jobs in the Redis job store.
+"""
+
 import argparse
 from datetime import UTC, datetime
 

--- a/search_gov_crawler/scheduling/jobstores.py
+++ b/search_gov_crawler/scheduling/jobstores.py
@@ -23,6 +23,13 @@ class SpiderRedisJobStore(RedisJobStore):
 
         return self._alias
 
+    def count_pending_jobs(self) -> int:
+        """Count the number of pending jobs in the job store"""
+
+        count = self.redis.zcard(self.pending_jobs_key)
+        log.debug("Counted %s pending jobs in key %s", count, self.pending_jobs_key)
+        return count
+
     def add_pending_job(self, job_id) -> None:
         """Add a job to the pending jobs set"""
 

--- a/search_gov_crawler/scheduling/redis.py
+++ b/search_gov_crawler/scheduling/redis.py
@@ -1,0 +1,10 @@
+import os
+
+
+def get_redis_connection_args() -> dict:
+    """Get the Redis connection arguments from environment variables."""
+    return {
+        "host": os.getenv("REDIS_HOST", "localhost"),
+        "port": int(os.getenv("REDIS_PORT", "6379")),
+        "db": 1,  # The searchgov app uses db 0
+    }

--- a/search_gov_crawler/scheduling/schedulers.py
+++ b/search_gov_crawler/scheduling/schedulers.py
@@ -36,12 +36,16 @@ class SpiderBackgroundScheduler(BackgroundScheduler):
         if jobstore:
             jobstore.add_pending_job(event.job_id)
 
+        log.info("Jobs in pending queue: %s", jobstore.count_pending_jobs())
+
     def remove_pending_job(self, event: JobExecutionEvent) -> None:
         """Remove a job from the pending jobs list in the case of success or error. Assume we mean redis."""
 
         jobstore = self._get_pending_jobstore()
         if jobstore:
             jobstore.remove_pending_job(event.job_id)
+
+        log.info("Jobs in pending queue: %s", jobstore.count_pending_jobs())
 
     def remove_pending_job_by_id(self, job_id: str) -> None:
         """Remove a job from the pending jobs list by job_id. Assume we mean redis."""
@@ -50,12 +54,16 @@ class SpiderBackgroundScheduler(BackgroundScheduler):
         if jobstore:
             jobstore.remove_pending_job(job_id)
 
+        log.info("Jobs in pending queue: %s", jobstore.count_pending_jobs())
+
     def remove_all_pending_jobs(self) -> None:
         """Remove all pending jobs from the job store.  Assume we mean redis."""
 
         jobstore = self._get_pending_jobstore()
         if jobstore:
             jobstore.remove_all_pending_jobs()
+
+        log.info("Jobs in pending queue: %s", jobstore.count_pending_jobs())
 
     def remove_all_jobs(self, jobstore: str | None = None, include_pending_jobs: bool = True) -> None:
         """Remove all jobs from the job store with an option to include pending jobs."""

--- a/tests/scheduling/conftest.py
+++ b/tests/scheduling/conftest.py
@@ -25,6 +25,10 @@ def fixture_mock_redis_jobstore() -> SpiderRedisJobStore:
         def lookup_job(*_args, **_kwargs):
             return True
 
+        @staticmethod
+        def zcard(*_args, **_kwargs):
+            return 0
+
     jobstore = SpiderRedisJobStore(pending_jobs_key="test_pending_jobs")
     jobstore._alias = "redis"
     jobstore.redis = MockRedisClient()

--- a/tests/scheduling/test_jobstores.py
+++ b/tests/scheduling/test_jobstores.py
@@ -47,6 +47,13 @@ GET_ALL_PENDING_JOB_TEST_CASES = [
 ]
 
 
+def test_count_pending_jobs(caplog, mock_redis_jobstore):
+    with caplog.at_level("DEBUG"):
+        mock_redis_jobstore.count_pending_jobs()
+
+    assert "Counted 0 pending jobs in key test_pending_jobs" in caplog.messages
+
+
 @pytest.mark.parametrize(("pending_job_ids", "lookup_job_result", "expected_messages"), GET_ALL_PENDING_JOB_TEST_CASES)
 def test_get_all_pending_jobs(
     caplog,

--- a/tests/scheduling/test_redis.py
+++ b/tests/scheduling/test_redis.py
@@ -1,0 +1,23 @@
+from search_gov_crawler.scheduling.redis import get_redis_connection_args
+
+
+def test_get_redis_connection_args_default(monkeypatch):
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_PORT", raising=False)
+
+    assert get_redis_connection_args() == {
+        "host": "localhost",
+        "port": 6379,
+        "db": 1,
+    }
+
+
+def test_get_redis_connection_args_custom(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "test-host")
+    monkeypatch.setenv("REDIS_PORT", "1234")
+
+    assert get_redis_connection_args() == {
+        "host": "test-host",
+        "port": 1234,
+        "db": 1,
+    }

--- a/tests/scheduling/test_schedulers.py
+++ b/tests/scheduling/test_schedulers.py
@@ -40,25 +40,33 @@ def fixture_job_execution_event() -> JobExecutionEvent:
 def test_add_pending_job(caplog, spider_scheduler, job_submission_event):
     with caplog.at_level("DEBUG"):
         spider_scheduler.add_pending_job(job_submission_event)
-    assert "Added test_job_id to pending jobs key test_pending_jobs" in caplog.messages
+
+    log_messages = ("Added test_job_id to pending jobs key test_pending_jobs", "Jobs in pending queue: 0")
+    assert all(log_message in caplog.messages for log_message in log_messages)
 
 
 def test_remove_pending_job(caplog, spider_scheduler, job_execution_event):
     with caplog.at_level("DEBUG"):
         spider_scheduler.remove_pending_job(job_execution_event)
-    assert "Removed test_job_id from pending jobs key test_pending_jobs" in caplog.messages
+
+    log_messages = ("Removed test_job_id from pending jobs key test_pending_jobs", "Jobs in pending queue: 0")
+    assert all(log_message in caplog.messages for log_message in log_messages)
 
 
 def test_remove_pending_job_by_id(caplog, spider_scheduler):
     with caplog.at_level("DEBUG"):
         spider_scheduler.remove_pending_job_by_id("test_job_id")
-    assert "Removed test_job_id from pending jobs key test_pending_jobs" in caplog.messages
+
+    log_messages = ("Removed test_job_id from pending jobs key test_pending_jobs", "Jobs in pending queue: 0")
+    assert all(log_message in caplog.messages for log_message in log_messages)
 
 
 def test_remove_all_pending_jobs(caplog, spider_scheduler):
     with caplog.at_level("DEBUG"):
         spider_scheduler.remove_all_pending_jobs()
-    assert "Removed all pending jobs from key test_pending_jobs" in caplog.messages
+
+    log_messages = ("Removed all pending jobs from key test_pending_jobs", "Jobs in pending queue: 0")
+    assert all(log_message in caplog.messages for log_message in log_messages)
 
 
 @pytest.mark.parametrize("include_pending_jobs", [True, False])


### PR DESCRIPTION
## Summary
- Added logging when jobs are added or removed from pending job store.
- Added `cache_tools.py` script with commands that allow someone to:
  - show all jobs in the scheduler
  - show all jobs in the pending queue
  - clear all jobs from the pending queue
  - show next run times for all scheduled jobs

### Testing
- For logging, start the scheduler with some upcoming jobs, ensure you see logging like "Jobs in pending queue: #" when jobs are added to the queue.  You can kill -SIGINT the pid in another session to stop the jobs and then you should see the "Jobs in pending queue: #" decrease to match the jobs in the queue.
- For the script, ensure that local redis is running, venv is sourced, and try the following commands;
  - `python scripts/cache_tools.py show-run-times` to show the next run times of schedule jobs
  - `python scripts/cache_tools.py show-pending-jobs` to show the jobs in the pending queue
  - `python scripts/cache_tools.py show-all-jobs` to show all jobs in the scheduler
  - `python scripts/cache_tools.py clear-pending-jobs` to clear all jobs from the pending queue

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
