### PR TITLE
SRCH-5953 Log Errors When Occurs On Starting Urls

### DIFF
--- a/search_gov_crawler/search_gov_spiders/middlewares.py
+++ b/search_gov_crawler/search_gov_spiders/middlewares.py
@@ -1,7 +1,8 @@
-# Define here the models for your spider middleware
-#
-# See documentation in:
-# https://docs.scrapy.org/en/latest/topics/spider-middleware.html
+"""Define here the models for your spider middleware
+
+See documentation in:
+https://docs.scrapy.org/en/latest/topics/spider-middleware.html
+"""
 
 import re
 import warnings
@@ -40,7 +41,7 @@ class SearchGovSpidersSpiderMiddleware(MiddlewareBase):
     # pylint: disable=unused-argument
     # disable unused arguments in this scrapy-generated class template
 
-    def process_spider_input(self, response, spider):
+    def process_spider_input(self, response, spider) -> None:
         """
         Called for each response that goes through the spider middleware and into the spider.
 
@@ -55,13 +56,19 @@ class SearchGovSpidersSpiderMiddleware(MiddlewareBase):
         """
         yield from result
 
-    def process_spider_exception(self, response, exception, spider):
+    def process_spider_exception(self, response, exception, spider) -> None:
         """Called when a spider or process_spider_input() method
         (from other spider middleware) raises an exception.
 
         Should return either None or an iterable of Request or item objects.
         """
-        return
+        if response.request.url in spider.start_urls:
+            spider.logger.exception(
+                "Error occured while accessing start url: %s: response: %s, %s",
+                response.request.url,
+                response,
+                exception,
+            )
 
     def process_start_requests(self, start_requests, spider):
         """
@@ -99,7 +106,8 @@ class SearchGovSpidersDownloaderMiddleware(MiddlewareBase):
             return
 
         if urlparse(request.url).query:
-            raise IgnoreRequest
+            msg = f"Ignoring request with query string: {request.url}"
+            raise IgnoreRequest(msg)
 
     def process_response(self, request, response, spider):
         """
@@ -170,5 +178,5 @@ class SearchGovSpidersOffsiteMiddleware(OffsiteMiddleware):
                 warnings.warn(message)
             else:
                 domains.append(re.escape(domain))
-        regex = rf'{"|".join(domains)}'
+        regex = rf"{'|'.join(domains)}"
         return re.compile(regex)

--- a/tests/search_gov_spiders/test_middlewares.py
+++ b/tests/search_gov_spiders/test_middlewares.py
@@ -1,13 +1,16 @@
-import pytest
+import re
 
+import pytest
 from scrapy import Request, Spider
 from scrapy.exceptions import IgnoreRequest
+from scrapy.http.response import Response
 from scrapy.utils.test import get_crawler
-from search_gov_crawler.search_gov_spiders.middlewares import (
-    SearchGovSpidersOffsiteMiddleware,
-    SearchGovSpidersDownloaderMiddleware,
-)
 
+from search_gov_crawler.search_gov_spiders.middlewares import (
+    SearchGovSpidersDownloaderMiddleware,
+    SearchGovSpidersOffsiteMiddleware,
+    SearchGovSpidersSpiderMiddleware,
+)
 
 MIDDLEWARE_TEST_CASES = [
     (["example.com"], ["example.com"], "http://www.example.com/1", True),
@@ -87,13 +90,46 @@ def test_spider_downloader_middleware():
         mw.process_request(request=request, spider=spider)
 
 
-def test_spider_downloader_middleware_allow_query_string():
+@pytest.mark.parametrize("allow_query_string", [True, False])
+def test_spider_downloader_middleware_allow_query_string(allow_query_string):
     # pylint: disable=protected-access
     crawler = get_crawler(Spider)
-    spider = crawler._create_spider(name="test", allow_query_string=True, allowed_domains="example.com")
+    spider = crawler._create_spider(name="test", allow_query_string=allow_query_string, allowed_domains="example.com")
     mw = SearchGovSpidersDownloaderMiddleware.from_crawler(crawler)
 
     mw.spider_opened(spider)
-    request = Request("http://www.example.com/test?parm=value")
 
-    assert mw.process_request(request=request, spider=spider) is None
+    request = Request("http://www.example.com/test?parm=value")
+    error_msg = f"Ignoring request with query string: {request.url}"
+    if allow_query_string:
+        assert mw.process_request(request=request, spider=spider) is None
+    else:
+        with pytest.raises(IgnoreRequest, match=re.escape(error_msg)):
+            mw.process_request(request=request, spider=spider)
+
+
+def test_spider_middleware_spider_exception_start_url(caplog):
+    # pylint: disable=protected-access
+    crawler = get_crawler(Spider)
+    spider = crawler._create_spider(
+        name="test",
+        allow_query_string=True,
+        allowed_domains="example.com",
+        start_urls=["http://www.example.com"],
+    )
+    mw = SearchGovSpidersSpiderMiddleware.from_crawler(crawler)
+
+    mw.spider_opened(spider)
+    response = Response(url="http://www.example.com", status=403, request=Request("http://www.example.com"))
+
+    with caplog.at_level("ERROR"):
+        mw.process_spider_exception(
+            response=response,
+            exception=IgnoreRequest("Igore this test request"),
+            spider=spider,
+        )
+        msg = (
+            "Error occured while accessing start url: http://www.example.com: "
+            "response: <403 http://www.example.com>, Igore this test request"
+        )
+        assert msg in caplog.messages


### PR DESCRIPTION
## Summary
The goal of this story is to log an `ERROR` level message when a spider encounters an error with one or more of the start URLs.  This only happens now if there is a DNS, timeout, or other connection error.  If there is a 403 or the start URL redirects out of the domain, we sometimes get an INFO message but it does not get into the cloudwatch filters that show log messages where `levelname == ERROR`.
- Originally considered sub-classing the built-in `HttpErrorMiddleware`
- But since we already have a `SearchGovSpidersSpiderMiddleware` that is not really doing anything, I just added a check in `process_spider_exception` and logged the error there.  Seemed cleaner not to mess with the built-in middleware if I didn't have to.
- Also needed to update the `SearchGovSpidersOffsiteMiddleware` to let us know when the starting url generates an offsite request.  Its been hard to find one of these working locally (since most of the AF domain examples give 403s locally) but if you set the starting url and allowed domain to different values, it works.
- Updated tests

### Testing
- Run a working crawl (quotes.toscrape.com or whatever) and confirm no logging issues.
- Running a crawl locally for `{ https://www.rs.af.mil/ | rs.af.mil }` returns 0 results due to a 403.  With this change, there should be a log message like  `Error occured while accessing start url:...` and info about the error
- You can try others that return a DNSError like `{ https://www.hancockfield.ang.af.mil/ | hancockfield.ang.af.mil }` but these were already logging an error.
- To mimic an Offsite Error run a scrape where the starting URL is not in the allowed domains like `{ https://quotes.toscrape.com | example.com }`

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
