### PR TITLE
Srch 5932 cannot access stopwords bug

### DIFF
--- a/search_gov_crawler/elasticsearch/convert_html_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_html_i14y.py
@@ -1,18 +1,18 @@
 import newspaper
-from search_gov_crawler.elasticsearch.parse_html_scrapy import convert_html_scrapy
-from search_gov_crawler.search_gov_spiders.helpers import content
-from search_gov_crawler.search_gov_spiders.helpers import encoding
+
 from search_gov_crawler.elasticsearch.i14y_helper import (
     ALLOWED_LANGUAGE_CODE,
-    parse_date_safely,
-    get_url_path,
-    get_base_extension,
     current_utc_iso,
-    generate_url_sha256,
-    get_domain_name,
     detect_lang,
+    generate_url_sha256,
+    get_base_extension,
+    get_domain_name,
+    get_url_path,
+    parse_date_safely,
     summarize_text,
 )
+from search_gov_crawler.elasticsearch.parse_html_scrapy import convert_html_scrapy
+from search_gov_crawler.search_gov_spiders.helpers import content, encoding
 
 
 def convert_html(response_bytes: bytes, url: str, response_language: str = None):
@@ -46,9 +46,11 @@ def convert_html(response_bytes: bytes, url: str, response_language: str = None)
     language = language[:2] if language else None
     valid_language = f"_{language}" if language in ALLOWED_LANGUAGE_CODE else ""
 
-    summary, keywords = summarize_text(text=main_content, lang_code=language)
-    tags = tags or keywords
-    description = description or summary
+    # Only run summarize text if either tags or description is not populated
+    if not (tags and description):
+        summary, keywords = summarize_text(text=main_content, lang_code=language)
+        tags = tags or keywords
+        description = description or summary
 
     return {
         "audience": article_backup["audience"],

--- a/search_gov_crawler/elasticsearch/convert_html_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_html_i14y.py
@@ -48,7 +48,7 @@ def convert_html(response_bytes: bytes, url: str, response_language: str = None)
 
     # Only run summarize text if either tags or description is not populated
     if not (tags and description):
-        summary, keywords = summarize_text(text=main_content, lang_code=language)
+        summary, keywords = summarize_text(text=main_content, url=url, lang_code=language)
         tags = tags or keywords
         description = description or summary
 

--- a/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
@@ -95,7 +95,7 @@ def convert_pdf(response_bytes: bytes, url: str, response_language: str = None):
     language = language[:2] if language else None
     valid_language = f"_{language}" if language in ALLOWED_LANGUAGE_CODE else ""
 
-    description, keywords = summarize_text(text=main_content, lang_code=language)
+    description, keywords = summarize_text(text=main_content, url=url, lang_code=language)
 
     time_now_str = current_utc_iso()
 

--- a/search_gov_crawler/elasticsearch/i14y_helper.py
+++ b/search_gov_crawler/elasticsearch/i14y_helper.py
@@ -75,12 +75,14 @@ def detect_lang(text: str) -> str:
     return None
 
 
-def summarize_text(text: str, lang_code: str = None):
+def summarize_text(text: str, url: str, lang_code: str = None):
     """
     Summarizes text and extracts keywords using nltk, and calculates execution time.
 
     Args:
         text (str): extracted text/content
+        url (str): url for logging
+        lang_code (str, optional): language code string
 
     Returns:
         tuple: (summary, keywords)
@@ -100,7 +102,7 @@ def summarize_text(text: str, lang_code: str = None):
     try:
         stop_words = set(stopwords.words(ALLOWED_LANGUAGE_CODE[lang_code]))
     except OSError as err:
-        msg = f"Unsupported Language. Missing Stopwords File: {err}"
+        msg = f"Unsupported Language. Error when parsing {url} Missing Stopwords File: {err}"
         logger.warning(msg)
         return empty_response
 

--- a/search_gov_crawler/elasticsearch/i14y_helper.py
+++ b/search_gov_crawler/elasticsearch/i14y_helper.py
@@ -3,33 +3,30 @@ import logging
 import os
 import re
 from datetime import UTC, datetime
+from typing import Any
 from urllib.parse import urlparse
-from dotenv import load_dotenv
+
 from dateutil import parser
+from dateutil.parser import ParserError
 from langdetect import detect
 from nltk.corpus import stopwords
 from nltk.tokenize import sent_tokenize, word_tokenize
-from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
-from pythonjsonlogger.json import JsonFormatter
-from typing import Any
-from dateutil.parser import ParserError
 
 # fmt: off
 ALLOWED_LANGUAGE_CODE = {
-    "ar": "arabic", "bg": "bulgarian", "bn": "bengali", "ca": "catalan", "cs": "czech", "da": "danish",
-    "de": "german", "el": "greek", "en": "english", "es": "spanish", "et": "estonian", "fa": "persian", "fr": "french",
-    "he": "hebrew", "hi": "hindi", "hr": "croatian", "ht": "haitian creole", "hu": "hungarian", "hy": "armenian", "id": "indonesian",
-    "it": "italian", "ja": "japanese", "km": "khmer", "ko": "korean", "lt": "lithuanian", "lv": "latvian", "mk": "macedonian",
-    "nl": "dutch", "pl": "polish", "ps": "pashto", "pt": "portuguese", "ro": "romanian", "ru": "russian", "sk": "slovak", "so": "somali",
-    "sq": "albanian", "sr": "serbian", "sw": "swahili", "th": "thai", "tr": "turkish", "uk": "ukrainian", "ur": "urdu", "uz": "uzbek",
-    "vi": "vietnamese", "zh": "chinese",
+    "ar": "arabic",     "bg": "bulgarian",      "bn": "bengali",   "ca": "catalan",   "cs": "czech",
+    "da": "danish",     "de": "german",         "el": "greek",     "en": "english",   "es": "spanish",
+    "et": "estonian",   "fa": "persian",        "fr": "french",    "he": "hebrew",    "hi": "hindi",
+    "hr": "croatian",   "ht": "haitian creole", "hu": "hungarian", "hy": "armenian",  "id": "indonesian",
+    "it": "italian",    "ja": "japanese",       "km": "khmer",     "ko": "korean",    "lt": "lithuanian",
+    "lv": "latvian",    "mk": "macedonian",     "nl": "dutch",     "pl": "polish",    "ps": "pashto",
+    "pt": "portuguese", "ro": "romanian",       "ru": "russian",   "sk": "slovak",    "so": "somali",
+    "sq": "albanian",   "sr": "serbian",        "sw": "swahili",   "th": "thai",      "tr": "turkish",
+    "uk": "ukrainian",  "ur": "urdu",           "uz": "uzbek",     "vi": "vietnamese", "zh": "chinese",
 }
 # fmt: on
 
-load_dotenv()
-logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
-logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
-logger = logging.getLogger("search_gov_crawler.i14y_helper")
+logger = logging.getLogger(__name__)
 
 
 def parse_date_safely(date_value: Any) -> str | None:
@@ -89,11 +86,25 @@ def summarize_text(text: str, lang_code: str = None):
         tuple: (summary, keywords)
     """
 
-    if (lang_code not in ALLOWED_LANGUAGE_CODE) or not text or type(text) != str:
-        return None, None
-    stop_words = set(stopwords.words(ALLOWED_LANGUAGE_CODE[lang_code]))
-    sentences = sent_tokenize(text)
+    empty_response = (None, None)
 
+    if not isinstance(text, str):
+        return empty_response
+
+    if not text:
+        return empty_response
+
+    if lang_code not in ALLOWED_LANGUAGE_CODE:
+        return empty_response
+
+    try:
+        stop_words = set(stopwords.words(ALLOWED_LANGUAGE_CODE[lang_code]))
+    except OSError as err:
+        msg = f"Unsupported Language. Missing Stopwords File: {err}"
+        logger.warning(msg)
+        return empty_response
+
+    sentences = sent_tokenize(text)
     word_frequencies = {}
     sentence_scores = {}
 

--- a/tests/search_gov_spiders/test_i14y_helper.py
+++ b/tests/search_gov_spiders/test_i14y_helper.py
@@ -111,24 +111,30 @@ def test_separate_file_name_only_extension():
 
 
 SUMMARIZE_TEXT_TEST_CASES = [
-    ("", "en", None, None),
-    (10, "en", None, None),
-    ("Hi there! I am testing this function", None, None, None),
-    ("Hi there! I am testing this function", "en", "I am testing this function Hi there!", "hi, testing, function"),
+    ("", "https://example.com", "en", None, None),
+    (10, "https://example.com", "en", None, None),
+    ("Hi there! I am testing this function", "https://example.com", None, None, None),
+    (
+        "Hi there! I am testing this function",
+        "https://example.com",
+        "en",
+        "I am testing this function Hi there!",
+        "hi, testing, function",
+    ),
 ]
 
 
-@pytest.mark.parametrize(("text", "lang_code", "summary", "keyword"), SUMMARIZE_TEXT_TEST_CASES)
-def test_summarize_text(text, lang_code, summary, keyword):
-    assert summarize_text(text=text, lang_code=lang_code) == (summary, keyword)
+@pytest.mark.parametrize(("text", "url", "lang_code", "summary", "keyword"), SUMMARIZE_TEXT_TEST_CASES)
+def test_summarize_text(text, url, lang_code, summary, keyword):
+    assert summarize_text(text=text, url=url, lang_code=lang_code) == (summary, keyword)
 
 
 def test_summarize_text_unsupported_stopwords(caplog):
     with caplog.at_level("WARNING"):
-        results = summarize_text("This is a test for missing stopwork", "ko")
+        results = summarize_text("This is a test for missing stopwork", "https://example.com", "ko")
 
     assert results == (None, None)
     assert (
-        f"Unsupported Language. Missing Stopwords File: No such file or directory: '{stopwords._root.path}/korean'"
+        f"Unsupported Language. Error when parsing https://example.com Missing Stopwords File: No such file or directory: '{stopwords._root.path}/korean'"
         in caplog.messages
     )

--- a/tests/search_gov_spiders/test_i14y_helper.py
+++ b/tests/search_gov_spiders/test_i14y_helper.py
@@ -1,7 +1,11 @@
+import pytest
+
+from nltk.corpus import stopwords
 from search_gov_crawler.elasticsearch.i14y_helper import (
-    parse_date_safely,
     detect_lang,
+    parse_date_safely,
     separate_file_name,
+    summarize_text,
 )
 
 
@@ -10,36 +14,26 @@ def test_parse_date_safely_valid_date():
     assert parse_date_safely("2025-03-13") == "2025-03-13T00:00:00"
 
 
-def test_for_known_date_issues():
-    sampleDates = {
-        "5/30/2024 7:24:49 AM": "2024-05-30T07:24:49",
-        "Wed, 02 Nov 1998": "1998-11-02T00:00:00",
-        "2025-03-14 00:00:00.0": "2025-03-14T00:00:00",
-        "2024-04-08 18:17:47-04:00": "2024-04-08T18:17:47",
-        "Thursday, August 10, 2023": "2023-08-10T00:00:00",
-        "January 8, 2013 10:05:30 AM EST": "2013-01-08T10:05:30",
-        "jibberish": None,
-        "2025-02-16T04:18:11.491+00:00": "2025-02-16T04:18:11",
-        "2024-02-22T00:00:00": "2024-02-22T00:00:00",
-    }
-    for date in sampleDates:
-        assert parse_date_safely(date) == sampleDates[date]
+PARSE_DATE_TEST_CASES = [
+    ("5/30/2024 7:24:49 AM", "2024-05-30T07:24:49"),
+    ("Wed, 02 Nov 1998", "1998-11-02T00:00:00"),
+    ("2025-03-14 00:00:00.0", "2025-03-14T00:00:00"),
+    ("2024-04-08 18:17:47-04:00", "2024-04-08T18:17:47"),
+    ("Thursday, August 10, 2023", "2023-08-10T00:00:00"),
+    ("January 8, 2013 10:05:30 AM EST", "2013-01-08T10:05:30"),
+    ("jibberish", None),
+    ("2025-02-16T04:18:11.491+00:00", "2025-02-16T04:18:11"),
+    ("2024-02-22T00:00:00", "2024-02-22T00:00:00"),
+    ("", None),
+    (None, None),
+    (0, None),
+    (False, None),
+]
 
 
-def test_parse_date_safely_empty_string():
-    assert parse_date_safely("") is None
-
-
-def test_parse_date_safely_none():
-    assert parse_date_safely(None) is None
-
-
-def test_parse_date_safely_zero():
-    assert parse_date_safely(0) is None
-
-
-def test_parse_date_safely_false():
-    assert parse_date_safely(False) is None
+@pytest.mark.parametrize(("input_str", "output_str"), PARSE_DATE_TEST_CASES)
+def test_for_known_date_issues(input_str, output_str):
+    assert parse_date_safely(input_str) == output_str
 
 
 # Tests for detect_lang
@@ -114,3 +108,27 @@ def test_separate_file_name_empty():
 
 def test_separate_file_name_only_extension():
     assert separate_file_name(".pdf") == ""
+
+
+SUMMARIZE_TEXT_TEST_CASES = [
+    ("", "en", None, None),
+    (10, "en", None, None),
+    ("Hi there! I am testing this function", None, None, None),
+    ("Hi there! I am testing this function", "en", "I am testing this function Hi there!", "hi, testing, function"),
+]
+
+
+@pytest.mark.parametrize(("text", "lang_code", "summary", "keyword"), SUMMARIZE_TEXT_TEST_CASES)
+def test_summarize_text(text, lang_code, summary, keyword):
+    assert summarize_text(text=text, lang_code=lang_code) == (summary, keyword)
+
+
+def test_summarize_text_unsupported_stopwords(caplog):
+    with caplog.at_level("WARNING"):
+        results = summarize_text("This is a test for missing stopwork", "ko")
+
+    assert results == (None, None)
+    assert (
+        f"Unsupported Language. Missing Stopwords File: No such file or directory: '{stopwords._root.path}/korean'"
+        in caplog.messages
+    )

--- a/tests/search_gov_spiders/test_i14y_html.py
+++ b/tests/search_gov_spiders/test_i14y_html.py
@@ -1,6 +1,7 @@
 from search_gov_crawler.elasticsearch import convert_html_i14y
 from search_gov_crawler.search_gov_spiders.helpers import content
 
+
 def test_convert_html_valid_article():
     html_content = """
     <html lang="en">
@@ -29,10 +30,11 @@ def test_convert_html_valid_article():
     assert result["language"] == "en"
     assert result["path"] == url
     assert result["basename"] == "test-article"
-    assert result["extension"] == None
+    assert result["extension"] is None
     assert result["domain_name"] == "example.com"
     assert result["url_path"] == "/test-article"
     assert len(result["_id"]) == 64  # SHA256 hash
+
 
 def test_convert_html_no_content():
     html_content = """
@@ -48,6 +50,7 @@ def test_convert_html_no_content():
     result = convert_html_i14y.convert_html(html_content.encode(), url, "en")
     assert result is None
 
+
 def test_convert_html_no_title_or_description():
     html_content = """
     <html lang="en">
@@ -60,11 +63,12 @@ def test_convert_html_no_title_or_description():
     """
     url = "https://example.com/test-article"
     result = convert_html_i14y.convert_html(html_content.encode(), url, "en")
-    content = "This is the main content of the test article."
+    expected_content = "This is the main content of the test article."
     assert result is not None
     assert result["title_en"] is None
-    assert result["description_en"] in content
-    assert "This is the main content of the test article." in result["content_en"]
+    assert result["description_en"] == expected_content
+    assert result["content_en"] == expected_content
+
 
 def test_convert_html_with_meta_site_name():
     html_content = """
@@ -84,6 +88,7 @@ def test_convert_html_with_meta_site_name():
     assert result["title_en"] == "Example Site"  # Uses meta_site_name
     assert "This is the main content." in result["content_en"]
 
+
 def test_convert_html_with_publish_date():
     html_content = """
     <html lang="en">
@@ -99,7 +104,8 @@ def test_convert_html_with_publish_date():
     url = "https://example.com/test-article"
     result = convert_html_i14y.convert_html(html_content.encode(), url, "en")
     assert result is not None
-    assert result["updated"] is not None # newspaper4k may or may not parse date from meta; this checks for any value.
+    assert result["updated"] is not None  # newspaper4k may or may not parse date from meta; this checks for any value.
+
 
 def test_convert_html_with_out_publish_date():
     html_content = """
@@ -116,8 +122,9 @@ def test_convert_html_with_out_publish_date():
     url = "https://example.com/test-article"
     result = convert_html_i14y.convert_html(html_content.encode(), url, "en")
     assert result is not None
-    assert result["updated"] is not ""
-    assert result["updated"] is None # newspaper4k may or may not parse date from meta; this checks for any value.
+    assert result["updated"] != ""
+    assert result["updated"] is None  # newspaper4k may or may not parse date from meta; this checks for any value.
+
 
 def test_convert_html_languages():
     html_content = """
@@ -137,10 +144,14 @@ def test_convert_html_languages():
         </html>
     """
     url = "https://example.cn/article"
-    
+
     result = convert_html_i14y.convert_html(html_content.encode(), url, "zh")
 
     assert result is not None
-    assert result["content_zh"] == "労化合測断秒化任面件気子人球分向無圧。了作果批入選教済球主運私信成笑論情禁。首着場研打表阪東日善能最囲値名陣必。想必愛交備見事新演内高青録断狙。詳期斉幕善確込対危継属会提円和動会分子。中常特処秘局創企真刊葉戸獲人師。前場明持二本聞通調写何観。薫大本設紋証済球取縮不園。辺案惑報湖買含応給奥専申琴真集情月続。"
+    assert result["content_zh"] == (
+        "労化合測断秒化任面件気子人球分向無圧。了作果批入選教済球主運私信成笑論情禁。首着場研打表阪東日善能最囲値名陣必。"
+        "想必愛交備見事新演内高青録断狙。詳期斉幕善確込対危継属会提円和動会分子。中常特処秘局創企真刊葉戸獲人師。前場明持二本聞通調写何観。"
+        "薫大本設紋証済球取縮不園。辺案惑報湖買含応給奥専申琴真集情月続。"
+    )
     assert result["title_zh"] == "Some Title"
     assert result["description_zh"] == content.sanitize_text("这是一个测试描述")

--- a/tests/search_gov_spiders/test_i14y_pdf.py
+++ b/tests/search_gov_spiders/test_i14y_pdf.py
@@ -32,7 +32,7 @@ def dummy_separate_file_name(filename):
     return "Fake Title from filename"
 
 
-def dummy_summarize_text(text, lang_code):
+def dummy_summarize_text(text, url, lang_code):
     # Return a tuple: (description, list of keywords)
     return ("Fake description", ["keyword1", "keyword2"])
 
@@ -92,8 +92,8 @@ def test_get_pdf_text():
     """Test that get_pdf_text concatenates text from each page."""
     fake_page_content_1 = """
     Lorem Ipsum is simply dummy text of the printing and typesetting industry.
-    Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, 
-    when an unknown printer took a galley of type and scrambled it to make a type specimen book. 
+    Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+    when an unknown printer took a galley of type and scrambled it to make a type specimen book.
     It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
     """
     fake_page_content_2 = f"Page 2 content: {fake_page_content_1}"
@@ -202,11 +202,11 @@ def test_get_links_set():
 
     fake_page2 = MagicMock()
     fake_page2.get_object.return_value = {}
-    
+
     page_items = [(page1_text, fake_page1), (page2_text, fake_page2)]
-    
+
     links = convert_pdf_i14y.get_links_set(page_items)
-    
+
     expected_links = {"https://example.com", "www.test.com"}
 
     assert set(links) == expected_links


### PR DESCRIPTION
## Summary
- Bug is we are seeing logs of errors about missing stop words files.  This is because for every doc we are trying to use the stopwords files from nltk and nltk does not support all the languages we support.
- Took two actions to fix this:
  - For HTML, since `summarize_text` where the error occurs is not the primary method for generating the `description` or `tags` fields, I moved it into a conditional so that it only runs when if it is needed.  Many of the error messages were appearing for cases when newspaper4k or `convert_html_scrapy` already generated values and the `summarize_text` values would be discarded anyway.  I did not do the same for PDFs since `summarize_text` is a primary data-generation method there.
  - Clarified the reasons why we return None from `summarize_text` and added a try/except block around getting the language from nltk.  Now, if we try to get a stopwords file that doesn't exist it logs a WARNING.
  - I added `url` as a argument so we can have some visibility in the logs as to which URL caused the error since this is not a spider logger we don't have the added spider stats.  I felt a little weird adding the arg just for logging but maybe not that bad.
  - Added a few tests.

### Testing
It was actually hard to find an example that logged an warning after these changes (which i think is a good thing and a result of moving `summarize_text` into a conditional.
I did find one:

Run 
`scrapy crawl domain_spider -a allowed_domains=uscis.gov -a start_urls="https://www.uscis.gov/humanitarian/humanitarian-or-significant-public-benefit-parole-for-aliens-outside-the-united-states/the-haitian-family-reunification-parole-hfrp-program-haitian-creole" -a output_target=elasticsearch -a depth_limit=1`

It takes a few minutes to finish but if you look back through the logs you will no OSError exceptions, but instead see:
`{"asctime": "2025-05-06 10:50:11,008", "name": "search_gov_crawler.elasticsearch.i14y_helper", "levelname": "WARNING", "message": "Unsupported Language. Error when parsing https://www.uscis.gov/sites/default/files/document/guides/HFRP-How-to-Check-If-Your-IV-is-Available-Haitian-Creole.pdf Missing Stopwords File: No such file or directory: '/Users/dself/nltk_data/corpora/stopwords/croatian'"}`

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
