### PR TITLE
SRCH-6030 update sitemap logging

### DIFF
--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -6,18 +6,14 @@ from typing import Any
 from urllib.parse import urlparse
 
 from elasticsearch import Elasticsearch, helpers  # pylint: disable=wrong-import-order
-from pythonjsonlogger.json import JsonFormatter
 from scrapy.spiders import Spider
 
 from search_gov_crawler.elasticsearch.convert_html_i14y import convert_html
 from search_gov_crawler.elasticsearch.convert_pdf_i14y import convert_pdf
-from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
 
 # limit excess INFO messages from elasticsearch that are not tied to a spider
 logging.getLogger("elastic_transport").setLevel("ERROR")
 
-logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
-logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
 log = logging.getLogger("search_gov_crawler.elasticsearch")
 
 """

--- a/search_gov_crawler/run_sitemap_monitor.py
+++ b/search_gov_crawler/run_sitemap_monitor.py
@@ -13,7 +13,7 @@ load_dotenv()
 
 logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
 logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
-log = logging.getLogger("search_gov_crawler.scrapy_scheduler")
+log = logging.getLogger("search_gov_crawler.run_sitemap_monitor")
 
 if __name__ == "__main__":
     log.info("Starting Sitemap Monitor...")

--- a/search_gov_crawler/run_sitemap_monitor.py
+++ b/search_gov_crawler/run_sitemap_monitor.py
@@ -1,8 +1,22 @@
-from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSites
-from search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor import SitemapMonitor
+import logging
+import os
+
+from dotenv import load_dotenv
+from pythonjsonlogger.json import JsonFormatter
+
 from search_gov_crawler.scrapy_scheduler import CRAWL_SITES_FILE
+from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSites
+from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
+from search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor import SitemapMonitor
+
+load_dotenv()
+
+logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
+logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+log = logging.getLogger("search_gov_crawler.scrapy_scheduler")
 
 if __name__ == "__main__":
-    records = CrawlSites.from_file(file=CRAWL_SITES_FILE) 
+    log.info("Starting Sitemap Monitor...")
+    records = CrawlSites.from_file(file=CRAWL_SITES_FILE)
     monitor = SitemapMonitor(records)
     monitor.run()

--- a/search_gov_crawler/search_gov_spiders/extensions/json_logging.py
+++ b/search_gov_crawler/search_gov_spiders/extensions/json_logging.py
@@ -81,10 +81,10 @@ class JsonLogging:
     def _add_json_handlers(self) -> None:
         """Try to add json hanlders for file and streaming"""
 
-        if not self.file_hanlder_enabled:
-            root_logger = logging.getLogger()
-            root_logger.setLevel(self.log_level)
+        root_logger = logging.getLogger()
+        root_logger.setLevel(self.log_level)
 
+        if not self.file_hanlder_enabled:
             file_handlers = [handler for handler in root_logger.handlers if isinstance(handler, logging.FileHandler)]
 
             for file_handler in file_handlers:
@@ -123,9 +123,7 @@ class JsonLogging:
         """Try to add hanlders and then log arguments passed to the spider"""
 
         self._add_json_handlers()
-        spider_log = logging.getLogger(spider.name)
-
-        spider_log.info(
+        spider.logger.info(
             (
                 "Starting spider %s with following args: "
                 "allowed_domains=%s allowed_domain_paths=%s start_urls=%s "

--- a/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_finder.py
+++ b/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_finder.py
@@ -1,14 +1,17 @@
-import re
-import os
 import csv
-import requests
+import logging
+import os
+import re
 from typing import Optional
 from urllib.parse import urljoin
-from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSites
-from search_gov_crawler.scrapy_scheduler import CRAWL_SITES_FILE
-from search_gov_crawler.search_gov_spiders.helpers.get_logger import GetSpiderLogger
 
-log = GetSpiderLogger("search_gov_crawler.search_gov_spiders.sitemaps")
+import requests
+
+from search_gov_crawler.scrapy_scheduler import CRAWL_SITES_FILE
+from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSites
+
+log = logging.getLogger(__name__)
+
 
 def write_dict_to_csv(data: dict, filename: str, overwrite: bool = False):
     """
@@ -36,9 +39,9 @@ def write_dict_to_csv(data: dict, filename: str, overwrite: bool = False):
         for key, value in data.items():
             writer.writerow([key, value])
 
+
 class SitemapFinder:
     def __init__(self):
-
         self.common_sitemap_names = [
             "sitemap.xml",
             "wp-sitemap.xml",
@@ -46,24 +49,23 @@ class SitemapFinder:
             "tag-sitemap.xml",
             "category-sitemap.xml",
             "sitemap1.xml",
-            "post-sitemap.xml"
-            "sitemap_index.xml",
+            "post-sitemap.xmlsitemap_index.xml",
             "sitemap-index.xml",
-            "sitemapindex.xml"
+            "sitemapindex.xml",
         ]
 
         self.timeout_seconds = 5
-    
+
     def _join_base(self, base_url: str, sitemap_path: str):
         if not sitemap_path.startswith(("http://", "https://")):
             return urljoin(base_url, sitemap_path)
         return sitemap_path
-    
+
     def _fix_http(self, url: str):
         if url.startswith(("http://")):
             return url.replace("http://", "https://")
         return url
-        
+
     def find(self, base_url) -> Optional[str]:
         """
         Find sitemap URL using multiple methods.
@@ -77,24 +79,24 @@ class SitemapFinder:
         sitemap_url = self._check_common_locations(base_url)
         if sitemap_url:
             return self._fix_http(sitemap_url)
-            
+
         # Method 2: Check robots.txt
         sitemap_url = self._check_robots_txt(base_url)
         if sitemap_url:
             return self._fix_http(sitemap_url)
-            
+
         # Method 3: Check HTML source
         sitemap_url = self._check_html_source(base_url)
         if sitemap_url:
             return self._fix_http(sitemap_url)
-            
+
         # Method 4: Check XML sitemaps in root directory
         sitemap_url = self._check_xml_files_in_root(base_url)
         if sitemap_url:
             return self._fix_http(sitemap_url)
-            
+
         return None
-    
+
     def confirm_sitemap_url(self, url: str | None) -> bool:
         """
         Uses HEAD request to confirm if the site map exists
@@ -108,28 +110,28 @@ class SitemapFinder:
             if response.status_code == 200:
                 return True
         except Exception:
-            pass          
+            pass
         return False
-    
+
     def _check_common_locations(self, base_url: str) -> Optional[str]:
         """Try common sitemap locations"""
         log.info(f"Method 1: Checking common sitemap locations for: {base_url}")
-        
+
         for name in self.common_sitemap_names:
             potential_url = urljoin(base_url, name)
             if self.confirm_sitemap_url(potential_url):
                 log.info(f"Method 1: Found sitemap at common location: {potential_url}")
                 return potential_url
         return None
-    
+
     def _check_robots_txt(self, base_url: str) -> Optional[str]:
         """Check robots.txt for Sitemap directive."""
         log.info(f"Method 2: Checking robots.txt to find sitemaps for: {base_url}")
-        
+
         try:
             robots_url = urljoin(base_url, "robots.txt")
             response = requests.get(robots_url, timeout=self.timeout_seconds)
-            
+
             if response.status_code == 200:
                 content = response.text
                 # Look for Sitemap: directive
@@ -141,18 +143,18 @@ class SitemapFinder:
         except Exception:
             # Silent pass, since it might be found in ofther locations
             pass
-                
+
         return None
-    
+
     def _check_html_source(self, base_url: str) -> Optional[str]:
         """Check HTML source for sitemap references."""
         log.info(f"Method 3: Checking HTML source to find sitemaps for: {base_url}")
-        
+
         try:
             response = requests.get(base_url, timeout=self.timeout_seconds)
             if response.status_code == 200:
                 html_content = response.text
-                
+
                 # Look for sitemap in link tags
                 link_pattern = r"<link[^>]*rel=[\"'](?:sitemap|alternate)[\"'][^>]*href=[\"']([^\"']+)[\"']"
                 matches = re.findall(link_pattern, html_content, re.IGNORECASE)
@@ -161,7 +163,7 @@ class SitemapFinder:
                     sitemap_url = self._join_base(base_url, sitemap_url)
                     log.info(f"Method 3: Found sitemap in HTML link tag: {sitemap_url}")
                     return sitemap_url
-                
+
                 # Look for any .xml files that might be sitemaps
                 xml_pattern = r"href=[\"']([^\"']*sitemap[^\"']*\.xml)[\"']"
                 matches = re.findall(xml_pattern, html_content, re.IGNORECASE)
@@ -170,11 +172,11 @@ class SitemapFinder:
                     sitemap_url = self._join_base(base_url, sitemap_path)
                     log.info(f"Method 3: Found sitemap reference in HTML: {sitemap_url}")
                     return sitemap_url
-                
+
         except Exception:
             # Silent pass, since it might be found in ofther locations
             pass
-            
+
         return None
 
     def _check_xml_files_in_root(self, base_url: str) -> Optional[str]:
@@ -183,27 +185,27 @@ class SitemapFinder:
         Check if we can find XML files that might be sitemaps.
         """
         log.info(f"Method 4: Checking for XML files in root directory to find sitemaps for: {base_url}")
-        
+
         try:
             response = requests.get(base_url, timeout=self.timeout_seconds)
             if response.status_code == 200:
                 html_content = response.text
-                
+
                 # Look for XML files that might be sitemaps
                 xml_pattern = r"href=[\"']([^\"']+\.xml)[\"']"
                 matches = re.findall(xml_pattern, html_content, re.IGNORECASE)
-                
+
                 for match in matches:
                     if "sitemap" in match.lower():
                         sitemap_url = urljoin(base_url, match)
                         if self.confirm_sitemap_url(sitemap_url):
                             log.info(f"Method 4: Found potential sitemap XML in directory: {sitemap_url}")
                             return sitemap_url
-                    
+
         except Exception:
             # Silent pass, since we already catch this exception outside
             pass
-            
+
         return None
 
 
@@ -218,7 +220,7 @@ def create_sitemaps_csv(csv_filename: str, batch_size: int = 10):
     """
     records = CrawlSites.from_file(file=CRAWL_SITES_FILE)
     sitemap_finder = SitemapFinder()
-    
+
     sitemap_dict = {}
     count = 1
 
@@ -243,7 +245,7 @@ def create_sitemaps_csv(csv_filename: str, batch_size: int = 10):
             write_dict_to_csv(sitemap_dict, csv_filename)
             sitemap_dict = {}
         count += 1
-    
+
     # save remaining items that did not hit batch_size mod
     write_dict_to_csv(sitemap_dict, csv_filename)
 

--- a/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_monitor.py
+++ b/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_monitor.py
@@ -282,9 +282,9 @@ class SitemapMonitor:
 
                 if new_urls:
                     log.info(f"Found {len(new_urls)} new URLs in {sitemap_url}")
-                    log.info("New URLs:")
-                    for url in sorted(new_urls):
-                        log.info(f"  - {url}")
+                    new_urls_msg_lines = ["New URLs:"]
+                    new_urls_msg_lines.extend([f"  - {url}" for url in sorted(new_urls)])
+                    log.info("\n".join(new_urls_msg_lines))
 
                     record = self.records_map[sitemap_url]
                     spider_args = {

--- a/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_monitor.py
+++ b/search_gov_crawler/search_gov_spiders/sitemaps/sitemap_monitor.py
@@ -1,32 +1,30 @@
-import os
 import gc
-import sys
-from dotenv import load_dotenv
-from pathlib import Path
-
-import requests
-import xml.etree.ElementTree as ET
-import time
-from datetime import datetime
-from typing import Dict, List, Set, Tuple, Any
 import hashlib
 import heapq
+import logging
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+from datetime import datetime
 from multiprocessing import Process
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
 
-from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSite
+import requests
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
+
+from search_gov_crawler.search_gov_spiders.crawl_sites import CrawlSite
+from search_gov_crawler.search_gov_spiders.sitemaps.sitemap_finder import SitemapFinder
 from search_gov_crawler.search_gov_spiders.spiders.domain_spider import DomainSpider
 from search_gov_crawler.search_gov_spiders.spiders.domain_spider_js import DomainSpiderJs
-from search_gov_crawler.search_gov_spiders.sitemaps.sitemap_finder import SitemapFinder
-from search_gov_crawler.search_gov_spiders.helpers.get_logger import GetSpiderLogger
 
-log = GetSpiderLogger("search_gov_crawler.search_gov_spiders.sitemaps")
-
-load_dotenv()
+log = logging.getLogger(__name__)
 
 
 TARGET_DIR = Path("/var/tmp/spider_sitemaps")
+
 
 def create_directory(path: Path) -> None:
     """Creates the directory using pathlib if it doesn't exist."""
@@ -40,9 +38,11 @@ def create_directory(path: Path) -> None:
         log.error(f"An unexpected error occurred creating directory '{path}': {e}", exc_info=True)
         sys.exit(1)
 
+
 def force_gc():
     ref_count = gc.collect()
     log.info(f"Cleaned {ref_count} unreachable objects.")
+
 
 def run_crawl_in_dedicated_process(spider_cls: type[DomainSpiderJs] | type[DomainSpider], spider_args: dict[str, Any]):
     """Runs a Scrapy spider in a new, dedicated process.
@@ -65,6 +65,7 @@ def run_crawl_in_dedicated_process(spider_cls: type[DomainSpiderJs] | type[Domai
     process.start()
     force_gc()
 
+
 class SitemapMonitor:
     def __init__(self, records: List[CrawlSite]):
         """Initialize the SitemapMonitor with crawl site records."""
@@ -78,7 +79,7 @@ class SitemapMonitor:
         # Filter records to only include those with depth_limit >= 8
         records = self.records
         records = [record for record in records if record.depth_limit >= 8]
-        
+
         sitemap_finder = SitemapFinder()
         records_len = len(records)
         records_count = 0
@@ -86,7 +87,7 @@ class SitemapMonitor:
             starting_url = record.starting_urls.split(",")[0]
             records_count += 1
             log.info(f"({records_count} of {records_len}) Checking sitemap for: {starting_url}")
-            
+
             # Default check interval is 48 hours if not specified
             record.check_sitemap_hours = (record.check_sitemap_hours or 48) * 3600
 
@@ -106,29 +107,29 @@ class SitemapMonitor:
         records = [record for record in records if record and record.sitemap_url]
 
         for i, record in enumerate(records):
-            if not hasattr(record, 'sitemap_url'):
+            if not hasattr(record, "sitemap_url"):
                 log.error(f"Record at index {i} is not a valid object: {record} (type: {type(record)})")
-        
+
         self.records_map = {record.sitemap_url: record for record in records}
         self.records = records
-        
+
         # Create data directory if it doesn't exist
         create_directory(TARGET_DIR)
-        
+
         # Load any previously stored sitemaps and set first run status
         self._load_stored_sitemaps()
-        
+
         # Initialize the next check times
         current_time = time.time()
         for record in self.records:
             self.next_check_times[record.sitemap_url] = current_time
-    
+
     def _load_stored_sitemaps(self) -> None:
         """Load previously stored sitemaps from disk if they exist and set first run status."""
         for record in self.records:
             url_hash = hashlib.md5(record.sitemap_url.encode()).hexdigest()
             file_path = TARGET_DIR / f"{url_hash}.txt"
-            
+
             if os.path.exists(file_path):
                 try:
                     with open(file_path, "r") as f:
@@ -142,12 +143,12 @@ class SitemapMonitor:
             else:
                 self.stored_sitemaps[record.sitemap_url] = set()
                 self.is_first_run[record.sitemap_url] = True
-                
+
     def _save_sitemap(self, sitemap_url: str, urls: Set[str]) -> None:
         """Save sitemap URLs to disk."""
         url_hash = hashlib.md5(sitemap_url.encode()).hexdigest()
         file_path = TARGET_DIR / f"{url_hash}.txt"
-        
+
         try:
             with open(file_path, "w") as f:
                 for url in sorted(urls):
@@ -155,16 +156,16 @@ class SitemapMonitor:
             log.info(f"Saved {len(urls)} URLs for {sitemap_url}")
         except Exception as e:
             log.error(f"Error saving sitemap for {sitemap_url}: {e}")
-    
+
     def _fetch_sitemap(self, url: str, depth: int = 0, max_depth: int = 10) -> Set[str]:
         """
         Fetch and parse a sitemap XML file recursively up to a maximum depth.
-        
+
         Args:
             url: The URL of the sitemap to fetch
             depth: Current recursion depth
             max_depth: Maximum recursion depth to prevent infinite loops
-            
+
         Returns:
             A set of URLs found in the sitemap
         """
@@ -178,13 +179,13 @@ class SitemapMonitor:
                 session.headers.update({"Cache-Control": "no-cache"})
                 session.cache_disabled = True
                 response = session.get(url, timeout=30)
-            
+
                 # Parse the XML
                 root = ET.fromstring(response.content)
-                
+
                 urls = set()
                 ns = root.tag.split("}")[0] + "}" if "}" in root.tag else ""
-                
+
                 if root.tag.endswith("sitemapindex"):
                     for sitemap in root.findall(f"{ns}sitemap"):
                         loc = sitemap.find(f"{ns}loc")
@@ -196,10 +197,10 @@ class SitemapMonitor:
                         loc = url_element.find(f"{ns}loc")
                         if loc is not None and loc.text:
                             urls.add(loc.text)
-                
+
                 log.info(f"Found {len(urls)} URLs in sitemap {url}")
                 return urls
-            
+
         except requests.exceptions.RequestException as e:
             log.error(f"Error fetching sitemap {url}: {e}")
             return set()
@@ -209,14 +210,14 @@ class SitemapMonitor:
         except Exception as e:
             log.error(f"Unexpected error processing sitemap {url}: {e}")
             return set()
-    
+
     def _check_for_changes(self, sitemap_url: str) -> Tuple[Set[str], int]:
         """
         Check a sitemap for new URLs, only storing on first run.
-        
+
         Args:
             sitemap_url: The URL of the sitemap to check
-            
+
         Returns:
             Tuple of (new URLs, total URLs count)
         """
@@ -238,51 +239,53 @@ class SitemapMonitor:
         except Exception as e:
             log.error(f"Error checking for changes in {sitemap_url}: {e}")
             return set(), 0
-    
+
     def _get_check_interval(self, url: str) -> int:
         """Get the check interval for a specific URL in seconds."""
         for record in self.records:
             if record.sitemap_url == url:
                 return record.check_sitemap_hours
         return 86400  # Default to 24 hours
-    
+
     def run(self) -> None:
         """Run the sitemap monitor continuously."""
         self.setup()
         log.info(f"Starting Sitemap Monitor for {len(self.records)} sitemaps")
-        
+
         for record in self.records:
             hours = record.check_sitemap_hours / 3600
             log.info(f"Check interval for {record.sitemap_url}: {hours:.1f} hours")
-        
+
         check_queue = []
         for record in self.records:
             heapq.heappush(check_queue, (self.next_check_times[record.sitemap_url], record.sitemap_url))
-        
+
         try:
             while True:
                 if not check_queue:
                     log.error("Check queue is empty. This shouldn't happen.")
                     break
-                
+
                 next_check_time, sitemap_url = heapq.heappop(check_queue)
                 current_time = time.time()
                 sleep_time = max(0, next_check_time - current_time)
-                
+
                 if sleep_time > 0:
                     next_check_str = datetime.fromtimestamp(next_check_time).strftime("%Y-%m-%d %H:%M:%S")
-                    log.info(f"Waiting until {next_check_str} to check {sitemap_url} (sleeping for {sleep_time:.1f} seconds)")
+                    log.info(
+                        f"Waiting until {next_check_str} to check {sitemap_url} (sleeping for {sleep_time:.1f} seconds)"
+                    )
                     time.sleep(sleep_time)
-                
+
                 log.info(f"Processing sitemap: {sitemap_url}")
                 new_urls, total_count = self._check_for_changes(sitemap_url)
-                
+
                 if new_urls:
                     log.info(f"Found {len(new_urls)} new URLs in {sitemap_url}")
                     log.info("New URLs:")
                     for url in sorted(new_urls):
                         log.info(f"  - {url}")
-                    
+
                     record = self.records_map[sitemap_url]
                     spider_args = {
                         "allow_query_string": record.allow_query_string,
@@ -294,21 +297,29 @@ class SitemapMonitor:
                         "depth_limit": 1,
                     }
                     spider_cls = DomainSpiderJs if record.handle_javascript else DomainSpider
-                    crawl_process = Process(target=run_crawl_in_dedicated_process, args=(spider_cls, spider_args,))
+                    crawl_process = Process(
+                        target=run_crawl_in_dedicated_process,
+                        args=(
+                            spider_cls,
+                            spider_args,
+                        ),
+                    )
                     crawl_process.start()
-                    crawl_process.join() # Wait for the crawl process to complete before continuing, forces blocking
+                    crawl_process.join()  # Wait for the crawl process to complete before continuing, forces blocking
                 else:
                     log.info(f"No new URLs found in {sitemap_url}")
-                
+
                 log.info(f"Total URLs in sitemap: {total_count}")
-                
+
                 check_interval = self._get_check_interval(sitemap_url)
                 self.next_check_times[sitemap_url] = time.time() + check_interval
-                next_check_str = datetime.fromtimestamp(self.next_check_times[sitemap_url]).strftime("%Y-%m-%d %H:%M:%S")
+                next_check_str = datetime.fromtimestamp(self.next_check_times[sitemap_url]).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
                 log.info(f"Next check for {sitemap_url} scheduled at {next_check_str}")
-                
+
                 heapq.heappush(check_queue, (self.next_check_times[sitemap_url], sitemap_url))
-                
+
         except KeyboardInterrupt:
             log.info("Sitemap Monitor stopped by user")
         except Exception as e:

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider.py
@@ -108,6 +108,7 @@ class DomainSpider(CrawlSpider):
 
         # store input args as private attributes for use in logging
         self._deny_paths = deny_paths
+        self._prevent_follow = prevent_follow
 
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, depth_limit: int | None = None, **kwargs) -> "DomainSpider":

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
@@ -135,6 +135,7 @@ class DomainSpiderJs(CrawlSpider):
 
         # store input args as private attributes for use in logging
         self._deny_paths = deny_paths
+        self._prevent_follow = prevent_follow
 
     @classmethod
     def from_crawler(cls, crawler: Crawler, *args, depth_limit: int | None = None, **kwargs) -> "DomainSpiderJs":


### PR DESCRIPTION
## Summary
- Goal is to reduce logging size for sitemap.  Did that in a few ways:
  - The main culprit is in the `JsonLogging` extension where the `start_urls` are being printed for each log message.  If it is a sitemap run, identified by `prevent_follow = True` we are no longer logging the list of these URLs, but instead a message ("Generated from Sitemap") that indicates the `start_urls` are generated by a sitemap.  Here you can see the start_urls value in the log messages go from a list of all the new URLs in the sitemap to a fixed length string:
    - <details><summary>Logs Before</summary>

      ```json
      {"asctime": "2025-05-27 15:35:18,640", "name": "scrapy.core.engine", "levelname": "INFO", "message": "Spider opened", "spider": {"name": "domain_spider", "allow_query_string": false, "allowed_domains": ["gps.gov"], "allowed_domain_paths": ["gps.gov"], "start_urls": ["https://www.gps.gov/", "https://www.gps.gov/applications/agriculture/", "https://www.gps.gov/applications/"], "output_target": "elasticsearch", "depth_limit": 1, "deny_paths": null}}
      {"asctime": "2025-05-27 15:35:18,645", "name": "domain_spider", "levelname": "INFO", "message": "Starting spider domain_spider with following args: allowed_domains=gps.gov allowed_domain_paths= start_urls=https://www.gps.gov/,https://www.gps.gov/applications/agriculture/,https://www.gps.gov/applications/ output_target=elasticsearch depth_limit=1 deny_paths=None"}
      ```
    - <details><summary>Logs After</summary>

      ```json
      {"asctime": "2025-05-28 10:35:06,807", "name": "scrapy.core.engine", "levelname": "INFO", "message": "Spider opened", "spider": {"name": "domain_spider", "allow_query_string": false, "allowed_domains": ["gps.gov"], "allowed_domain_paths": ["gps.gov"], "start_urls": "Generated from Sitemap", "output_target": "elasticsearch", "depth_limit": 1, "deny_paths": null}}
      {"asctime": "2025-05-28 10:35:06,814", "name": "domain_spider", "levelname": "INFO", "message": "Starting spider domain_spider with following args: allowed_domains=gps.gov allowed_domain_paths= start_urls=Generated from Sitemap output_target=elasticsearch depth_limit=1 deny_paths=None", "spider": {"name": "domain_spider", "allow_query_string": false, "allowed_domains": ["gps.gov"], "allowed_domain_paths": ["gps.gov"], "start_urls": "Generated from Sitemap", "output_target": "elasticsearch", "depth_limit": 1, "deny_paths": null}}
      ```
      </details>

  - Also fixed the duplicate logging issue by adjusting the `JsonLogging` extension.  When we call CrawlerProcess it adds another `logging.StreamHandler` to the root logger along side the `SearchGovSpiderStreamHandler`.  Now, when the `JsonLogging` extension initializes or opens a spider it removes any of these stream handlers from the standard library.  It continues to ensure that a `SearchGovSpiderStreamHandler` is attached.
  - Adjusted the logging of New URLs found by the sitemap monitor.  When trying to filter in cloudwatch or elsewhere it seems like it would be easier to find/count/correlate new URLs if they are all on the same line.  The newlines are still there just inside the message.  This also cuts log size a bit but mostly for increased ability to search and filter.
    - <details><summary>Logs Before</summary>

      ```json
      {"asctime": "2025-05-27 15:35:16,543", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "New URLs:"}
      {"asctime": "2025-05-27 15:35:16,543", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "  - https://www.gps.gov/"}
      {"asctime": "2025-05-27 15:35:16,543", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "  - https://www.gps.gov/applications/"}
      {"asctime": "2025-05-27 15:35:16,543", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "  - https://www.gps.gov/applications/agriculture/"}
      ```
    - <details><summary>Logs After</summary>

      ```json
      {"asctime": "2025-05-28 10:35:04,729", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "Found 3 new URLs in https://www.gps.gov/sitemap.xml"}
      {"asctime": "2025-05-28 10:35:04,729", "name": "search_gov_crawler.search_gov_spiders.sitemaps.sitemap_monitor", "levelname": "INFO", "message": "New URLs:\n  - https://www.gps.gov/\n  - https://www.gps.gov/applications/\n  - https://www.gps.gov/applications/agriculture/"}
      ```
      </details>

  - Finally, removed the usage of `GetSpiderLogger` since its not necessary.  Did not remove just in case but I'd consider it deprecated at this point.  Also tried to standardize the config of logging to happen just in the three entry point files.
  - The extra whitespaces removed from monitor and finder is something my IDE did when I made logging-specific updates but I think is valid.
  - Updated `JsonLogging` extension tests

### Testing
All tests are using the sample json file from the sitemaps PR:
<details>
<summary>JSON file</summary>

```json
[
   {
      "allow_query_string": false,
      "allowed_domains": "example.mill",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "Test sitemap",
      "output_target": "elasticsearch",
      "schedule": "18 07 * * SUN",
      "sitemap_url": "http://localhost:8000/sitemap.xml",
      "starting_urls": "https://www.example.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "et.usembassy.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "US Embassy Ethiopia (dos_emb_afr_ethiopia)",
      "output_target": "elasticsearch",
      "schedule": "27 08 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://et.usembassy.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "dcaa.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "DCAA (dod_dcaa)",
      "output_target": "elasticsearch",
      "schedule": "36 10 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://www.dcaa.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "centcom.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "CENTCOM (centcom)",
      "output_target": "elasticsearch",
      "schedule": "45 11 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://www.centcom.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "afdc.energy.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "AFDC (afdc.energy.gov)",
      "output_target": "elasticsearch",
      "schedule": "54 12 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://afdc.energy.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "il.usembassy.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "US Embassy Israel (dos_emb_mena_israel)",
      "output_target": "elasticsearch",
      "schedule": "03 13 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://il.usembassy.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "quartermaster.army.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "Quartermaster (qm)",
      "output_target": "elasticsearch",
      "schedule": "25 15 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://quartermaster.army.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "lrd.usace.army.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "Great Lakes Division (greatlakes_div)",
      "output_target": "elasticsearch",
      "schedule": "36 16 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://www.lrd.usace.army.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "dpaa.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "DPAA (dpaa)",
      "output_target": "elasticsearch",
      "schedule": "47 17 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://www.dpaa.mil"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "mymarketnews.ams.usda.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "My Market News (mymarketnews)",
      "output_target": "elasticsearch",
      "schedule": "15 18 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://mymarketnews.ams.usda.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "fca.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "FCA (fca)",
      "output_target": "elasticsearch",
      "schedule": "58 19 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://www.fca.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "gps.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "GPS.gov (gps.gov)",
      "output_target": "elasticsearch",
      "schedule": "15 20 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://www.gps.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "bd.usembassy.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "US Embassy Dhaka (dos_emb_csa_dhaka)",
      "output_target": "elasticsearch",
      "schedule": "15 22 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://bd.usembassy.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "gh.usembassy.gov",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "US Embassy Accra (dos_emb_afr_accra)",
      "output_target": "elasticsearch",
      "schedule": "15 23 * * MON",
      "sitemap_url": null,
      "starting_urls": "https://gh.usembassy.gov"
   },
   {
      "allow_query_string": false,
      "allowed_domains": "cdmrp.health.mil",
      "check_sitemap_hours": null,
      "deny_paths": null,
      "depth_limit": 8,
      "handle_javascript": false,
      "name": "CDMRP (cdmrp)",
      "output_target": "elasticsearch",
      "schedule": "15 00 * * SUN",
      "sitemap_url": null,
      "starting_urls": "https://cdmrp.health.mil"
   }
]

```

</details>

- Run the sitemap monitor to capture sitemaps.
- Edit the d9f535b4944b795332784038cbe79c3f.txt file to remove a few URLS
- Edit the 8c2e4c759554bdf8f1d26c36c8c8f2c7.txt file to remove a few URLS
- Rerun the sitemap monitor, it should detect the changes and run two spiders.
- Verify:
  - Logs match "Logs After" format as described above, mostly that log messages include "Generated from Sitemap" instead of a list of URLs.
  - Double logging is no longer present.

- Run a scrapy scrawl, benchmark, and/or scrapy_scheduler run to ensure logging still works for these as expected.  You should still see json logging, continue not to see duplicate logging, and not see "Generated from Sitemap" anywhere.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
