### PR TITLE
SRCH-5918 Unique Job Id In Crawl List

### DIFF
--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -130,7 +130,7 @@ def benchmark_from_file(input_file: Path, runtime_offset_seconds: int):
     for crawl_site in crawl_sites:
         apscheduler_job = create_apscheduler_job(
             runtime_offset_seconds=runtime_offset_seconds,
-            **crawl_site.to_dict(exclude=("schedule", "sitemap_url", "check_sitemap_hours")),
+            **crawl_site.to_dict(exclude=("schedule", "sitemap_url", "check_sitemap_hours", "job_id")),
         )
         scheduler.add_job(**apscheduler_job, jobstore="memory")
     scheduler.start()

--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -82,8 +82,7 @@ def create_apscheduler_job(
     runtime_offset_seconds: int,
     depth_limit: int,
     deny_paths: str,
-    sitemap_url: str = None,
-    check_sitemap_hours: int = None,
+    job_id: str = None,
 ) -> dict:
     """Creates job record in format needed by apscheduler"""
 
@@ -91,7 +90,7 @@ def create_apscheduler_job(
 
     return {
         "func": scrapy_scheduler.run_scrapy_crawl,
-        "id": job_name,
+        "id": job_id if job_id else job_name,
         "name": job_name,
         "next_run_time": datetime.now(tz=UTC) + timedelta(seconds=runtime_offset_seconds),
         "args": [
@@ -130,7 +129,7 @@ def benchmark_from_file(input_file: Path, runtime_offset_seconds: int):
     for crawl_site in crawl_sites:
         apscheduler_job = create_apscheduler_job(
             runtime_offset_seconds=runtime_offset_seconds,
-            **crawl_site.to_dict(exclude=("schedule", "sitemap_url", "check_sitemap_hours", "job_id")),
+            **crawl_site.to_dict(exclude=("schedule", "sitemap_url", "check_sitemap_hours")),
         )
         scheduler.add_job(**apscheduler_job, jobstore="memory")
     scheduler.start()
@@ -147,8 +146,6 @@ def benchmark_from_args(
     runtime_offset_seconds: int,
     depth_limit: int,
     deny_paths: str,
-    sitemap_url: str = None,
-    check_sitemap_hours: int = None,
 ):
     """Run an individual benchmarking job based on args"""
 
@@ -156,7 +153,7 @@ def benchmark_from_args(
         "Starting benchmark from args! "
         "allow_query_string=%s allowed_domains=%s starting_urls=%s "
         "handle_javascript=%s output_target=%s runtime_offset_seconds=%s "
-        "depth_limit=%s deny_paths=%s sitemap_url=%s check_sitemap_hours=%s"
+        "depth_limit=%s deny_paths=%s"
     )
     log.info(
         msg,
@@ -168,8 +165,6 @@ def benchmark_from_args(
         runtime_offset_seconds,
         depth_limit,
         deny_paths,
-        sitemap_url,
-        check_sitemap_hours,
     )
 
     apscheduler_job_kwargs = {
@@ -182,8 +177,6 @@ def benchmark_from_args(
         "runtime_offset_seconds": runtime_offset_seconds,
         "depth_limit": depth_limit,
         "deny_paths": deny_paths.split(","),
-        "sitemap_url": sitemap_url,
-        "check_sitemap_hours": check_sitemap_hours,
     }
 
     scheduler = init_scheduler()

--- a/search_gov_crawler/domains/config/domains_elasticsearch.libsonnet
+++ b/search_gov_crawler/domains/config/domains_elasticsearch.libsonnet
@@ -10723,7 +10723,7 @@ local output_target = 'elasticsearch';
                          depth_limit=3),
   },
   {
-    name: 'Broadband USA (bbusa)',
+    name: 'NTIA (bbusa)',
     config: DomainConfig(allowed_domains='ntia.gov',
                          starting_urls='https://www.ntia.gov',
                          schedule='52 22 * * FRI',

--- a/search_gov_crawler/domains/crawl-sites-production.json
+++ b/search_gov_crawler/domains/crawl-sites-production.json
@@ -17882,7 +17882,7 @@
       "deny_paths": null,
       "depth_limit": 3,
       "handle_javascript": false,
-      "name": "Broadband USA (bbusa)",
+      "name": "NTIA (bbusa)",
       "output_target": "elasticsearch",
       "schedule": "52 22 * * FRI",
       "sitemap_url": null,

--- a/search_gov_crawler/domains/crawl-sites-staging.json
+++ b/search_gov_crawler/domains/crawl-sites-staging.json
@@ -17882,7 +17882,7 @@
       "deny_paths": null,
       "depth_limit": 3,
       "handle_javascript": false,
-      "name": "Broadband USA (bbusa)",
+      "name": "NTIA (bbusa)",
       "output_target": "elasticsearch",
       "schedule": "52 22 * * FRI",
       "sitemap_url": null,

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -90,7 +90,7 @@ def transform_crawl_sites(crawl_sites: CrawlSites) -> list[dict]:
         transformed_crawl_sites.append(
             {
                 "func": run_scrapy_crawl,
-                "id": job_name.lower().replace(" ", "-").replace("---", "-"),
+                "id": crawl_site.job_id,
                 "name": job_name,
                 "trigger": CronTrigger.from_crontab(expr=crawl_site.schedule, timezone="UTC"),
                 "args": [

--- a/tests/search_gov_spiders/test_benchmark.py
+++ b/tests/search_gov_spiders/test_benchmark.py
@@ -63,8 +63,6 @@ def test_create_apscheduler_job(handle_javascript, spider_arg):
         "runtime_offset_seconds": 5,
         "depth_limit": 3,
         "deny_paths": "/deny-path1/,/deny-path2/",
-        "sitemap_url": None,
-        "check_sitemap_hours": None,
     }
 
     assert create_apscheduler_job(**test_args) == {
@@ -114,8 +112,6 @@ def test_benchmark_from_args(caplog, monkeypatch, mock_es_client):
             "runtime_offset_seconds": 0,
             "depth_limit": 3,
             "deny_paths": "/deny-path1/,/deny-path2/",
-            "sitemap_url": None,
-            "check_sitemap_hours": None,
         }
         with caplog.at_level("INFO"):
             benchmark_from_args(**test_args)
@@ -123,8 +119,7 @@ def test_benchmark_from_args(caplog, monkeypatch, mock_es_client):
         expected_log_msg = (
             "Starting benchmark from args! allow_query_string=True allowed_domains=unit-test.example.com "
             "starting_urls=https://unit-test.example.com handle_javascript=False output_target=csv "
-            "runtime_offset_seconds=0 depth_limit=3 deny_paths=/deny-path1/,/deny-path2/ sitemap_url=None "
-            "check_sitemap_hours=None"
+            "runtime_offset_seconds=0 depth_limit=3 deny_paths=/deny-path1/,/deny-path2/"
         )
         assert expected_log_msg in caplog.messages
 


### PR DESCRIPTION
## Summary
- Found two records with different domain but same name which was not covered in our crawl site checks.
- There was already a story in the backlog for adding this type of constraint so I did it instead of just fixing the json.
  - Added new field to CrawlSite: job_id
  - This is the same value that was being calculated in scrapy_scheduler but moved the logic into CralwSites.
  - APScheduler requires a unique value for this field as it is used to identify jobs
  - Added unique check for id in crawl sites
  - Updated benchmark to conditionally include job_id (and removed sitemap stuff since it was excluded)

### Testing
- Perform regression testing to ensure no issues with
  - `scrapy crawl` crawls
  - benchmark crawls
  - scrapy scheduler crawls
  - sitemap update runs

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
