### PR TITLE
SRCH-6052 DAP Visits On Doc

### DIFF
--- a/search_gov_crawler/elasticsearch/convert_html_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_html_i14y.py
@@ -79,4 +79,5 @@ def convert_html(response_bytes: bytes, url: str, response_language: str = None)
         "extension": extension or None,
         "url_path": get_url_path(url),
         "domain_name": get_domain_name(url),
+        "dap_domain_visits_count": 0,
     }

--- a/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
@@ -1,7 +1,6 @@
 import re
 from datetime import datetime, timedelta
 from io import BytesIO
-from typing import Tuple
 
 from pypdf import PageObject, PdfReader
 
@@ -35,7 +34,7 @@ def add_title_and_filename(key: str, title_key: str, doc: dict):
     doc[key] = f"{doc[title_key]} {doc['basename']}.{doc['extension']} {doc[key]}"
 
 
-def get_links_set(pages: list[Tuple[str, PageObject]]):
+def get_links_set(pages: list[tuple[str, PageObject]]):
     """
     Returns a set of links for all pages in the PDF
 
@@ -132,6 +131,7 @@ def convert_pdf(response_bytes: bytes, url: str, response_language: str = None):
         "extension": extension or None,
         "url_path": get_url_path(url),
         "domain_name": get_domain_name(url),
+        "dap_domain_visits_count": 0,
     }
 
     add_title_and_filename(content_key, title_key, i14y_doc)
@@ -142,7 +142,7 @@ def convert_pdf(response_bytes: bytes, url: str, response_language: str = None):
     return i14y_doc
 
 
-def get_pdf_text(reader: PdfReader) -> Tuple[str, list[Tuple[str, PageObject]]]:
+def get_pdf_text(reader: PdfReader) -> tuple[str, list[tuple[str, PageObject]]]:
     """
     Returns clean text/content from all pdf pages
 

--- a/search_gov_crawler/elasticsearch/i14y_helper.py
+++ b/search_gov_crawler/elasticsearch/i14y_helper.py
@@ -12,6 +12,8 @@ from langdetect import detect
 from nltk.corpus import stopwords
 from nltk.tokenize import sent_tokenize, word_tokenize
 
+from search_gov_crawler.search_gov_spiders.spiders import SearchGovDomainSpider
+
 # fmt: off
 ALLOWED_LANGUAGE_CODE = {
     "ar": "arabic",     "bg": "bulgarian",      "bn": "bengali",   "ca": "catalan",   "cs": "czech",
@@ -178,3 +180,25 @@ def get_domain_name(url: str) -> str:
     url = ensure_http_prefix(url)
     parsed = urlparse(url)
     return parsed.netloc
+
+
+def update_dap_visits_to_document(document: dict, spider: SearchGovDomainSpider) -> dict:
+    """
+    The purpose of this function is to look in the domain_visits dict present on the spider
+    and if there is a match update the value.
+
+    This function assumes that
+      - The `dap_domain_visits_count` is being set to 0 on during the creation of all documents.
+      - The `domain_name` field exists on all documents
+      - The `domain_visits` dict exists on all spiders
+    """
+
+    try:
+        domain_name = document.get("domain_name")
+    except KeyError:
+        logger.exception("Missing domain_name on doc id %s. Could not apply dap visits.", document.get("id"))
+
+    if dap_visits := spider.domain_visits.get(domain_name):
+        document["dap_domain_visits_count"] = dap_visits
+
+    return document

--- a/search_gov_crawler/elasticsearch/i14y_helper.py
+++ b/search_gov_crawler/elasticsearch/i14y_helper.py
@@ -185,7 +185,8 @@ def get_domain_name(url: str) -> str:
 def update_dap_visits_to_document(document: dict, spider: SearchGovDomainSpider) -> dict:
     """
     The purpose of this function is to look in the domain_visits dict present on the spider
-    and if there is a match update the value.
+    and if there is a match update the value.  A leading `www.` is removed if it exists to match
+    values normalized by the DAP extractor process.
 
     This function assumes that
       - The `dap_domain_visits_count` is being set to 0 on during the creation of all documents.
@@ -194,9 +195,10 @@ def update_dap_visits_to_document(document: dict, spider: SearchGovDomainSpider)
     """
 
     try:
-        domain_name = document.get("domain_name")
+        domain_name = str(document["domain_name"]).removeprefix("www.")
     except KeyError:
         logger.exception("Missing domain_name on doc id %s. Could not apply dap visits.", document.get("id"))
+        return document
 
     if dap_visits := spider.domain_visits.get(domain_name):
         document["dap_domain_visits_count"] = dap_visits

--- a/search_gov_crawler/scheduling/redis.py
+++ b/search_gov_crawler/scheduling/redis.py
@@ -1,6 +1,9 @@
+import logging
 import os
 
 from redis import Redis
+
+log = logging.getLogger(__name__)
 
 
 def get_redis_connection_args(db: int = 1) -> dict:
@@ -16,4 +19,7 @@ def init_redis_client(**extra_args) -> Redis:
     """Initialize a Redis client using connection arguments from environment variables."""
     # Create a Redis client with the connection arguments
     redis_connection_args = get_redis_connection_args()
-    return Redis(**redis_connection_args, **extra_args)
+    redis_connection_args.update(extra_args)
+    log.debug("Attempting conection to redis with args %s", redis_connection_args)
+
+    return Redis(**redis_connection_args)

--- a/search_gov_crawler/search_gov_spiders/helpers/domain_spider.py
+++ b/search_gov_crawler/search_gov_spiders/helpers/domain_spider.py
@@ -90,7 +90,7 @@ def is_valid_content_type(content_type_header: str, output_target: str) -> bool:
 
 
 def get_simple_content_type(content_type_header: str, output_target: str) -> str:
-    """Returns simple content time like: \"text/html\" """
+    r"""Returns simple content time like: \"text/html\" """
     if not content_type_header:
         return None
     content_type_header = str(content_type_header)

--- a/search_gov_crawler/search_gov_spiders/spiders/__init__.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/__init__.py
@@ -2,3 +2,9 @@
 #
 # Please refer to the documentation for information on how to create and manage
 # your spiders.
+from typing import TypeVar
+
+from .domain_spider import DomainSpider
+from .domain_spider_js import DomainSpiderJs
+
+SearchGovDomainSpider = TypeVar("SearchGovDomainSpider", DomainSpider, DomainSpiderJs)

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider.py
@@ -110,6 +110,9 @@ class DomainSpider(CrawlSpider):
         self._deny_paths = deny_paths
         self._prevent_follow = prevent_follow
 
+        # gather domain visits for domain and subdomains
+        self.domain_visits = helpers.get_domain_visits(self)
+
         # create unique id to help with job state queues and elsewhere
         self.spider_id = helpers.generate_spider_id_from_args(
             self.name,

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
@@ -137,6 +137,9 @@ class DomainSpiderJs(CrawlSpider):
         self._deny_paths = deny_paths
         self._prevent_follow = prevent_follow
 
+        # gather domain visits for domain and subdomains
+        self.domain_visits = helpers.get_domain_visits(self)
+
         # create unique id to help with job state queues and elsewhere
         self.spider_id = helpers.generate_spider_id_from_args(
             self.name,

--- a/tests/scheduling/test_redis.py
+++ b/tests/scheduling/test_redis.py
@@ -49,3 +49,18 @@ def test_init_redis_client(monkeypatch, mock_redis_client):
 
     monkeypatch.setattr("search_gov_crawler.scheduling.redis.Redis", mock_redis)
     assert init_redis_client().ping()
+
+
+@pytest.mark.usefixtures("clear_redis_env_vars")
+def test_init_redis_client_with_extra_args(caplog, monkeypatch, mock_redis_client):
+    extra_args = {"db": 5, "new": "connection arg"}
+    expected_connection_args = {"host": "localhost", "port": 6379, "db": 5, "new": "connection arg"}
+
+    def mock_redis(*_args, **_kwargs):
+        return mock_redis_client
+
+    monkeypatch.setattr("search_gov_crawler.scheduling.redis.Redis", mock_redis)
+    with caplog.at_level("DEBUG"):
+        init_redis_client(**extra_args)
+
+    assert f"Attempting conection to redis with args {expected_connection_args}" in caplog.messages

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -1,11 +1,11 @@
-import os
 import asyncio
+
 import pytest
-from unittest.mock import patch, MagicMock
-from search_gov_crawler.elasticsearch.es_batch_upload import SearchGovElasticsearch
 from elasticsearch import Elasticsearch
 
-html_content = """
+from search_gov_crawler.elasticsearch.es_batch_upload import SearchGovElasticsearch
+
+HTML_CONTNET = """
     <html lang="en">
     <head>
         <title>Test Article Title</title>
@@ -21,72 +21,76 @@ html_content = """
     </html>
 """
 
-response_bytes = html_content.encode()
+RESPONSE_BYTES = HTML_CONTNET.encode()
 
 
-@pytest.fixture
-def sample_spider():
+@pytest.fixture(name="sample_spider")
+def fixture_sample_spider(mocker):
     """Fixture for a mock spider with a logger."""
 
     class SpiderMock:
-        logger = MagicMock()
+        logger = mocker.MagicMock()
 
     return SpiderMock()
 
 
 # Mock environment variables
-@pytest.fixture(autouse=True)
-def search_gov_es():
-    with patch.dict(
-        os.environ,
+@pytest.fixture(autouse=True, name="search_gov_es")
+def fixture_search_gov_es(mocker):
+    mocker.patch.dict(
+        "os.environ",
         {
             "ES_HOSTS": "http://localhost:9200",
             "SEARCHELASTIC_INDEX": "test_index",
             "ES_USER": "test_user",
             "ES_PASSWORD": "test_password",
         },
-    ):
-        yield SearchGovElasticsearch(batch_size=2)
+    )
+    return SearchGovElasticsearch(batch_size=2)
 
 
-@pytest.fixture
-def mock_es_client():
-    client = MagicMock(spec=Elasticsearch)
-    client.indices = MagicMock()
-    client.indices.exists = MagicMock()
-    client.indices.create = MagicMock()
+@pytest.fixture(name="mock_es_client")
+def fixture_mock_es_client(mocker):
+    client = mocker.MagicMock(spec=Elasticsearch)
+    client.indices = mocker.MagicMock()
+    client.indices.exists = mocker.MagicMock()
+    client.indices.create = mocker.MagicMock()
     return client
 
 
 # Mock convert_html function
-@pytest.fixture
-def mock_convert_html():
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.convert_html") as mock:
-        yield mock
+@pytest.fixture(name="mock_convert_html")
+def fixture_mock_convert_html(mocker):
+    return mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.convert_html")
 
 
-@pytest.fixture()
-def mock_asyncio_loop():
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.get_event_loop") as mock_get_loop:
-        mock_loop = asyncio.new_event_loop()
-        mock_get_loop.return_value = mock_loop
+@pytest.fixture(name="mock_asyncio_loop")
+def fixture_mock_asyncio_loop(mocker):
+    mock_get_loop = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.get_event_loop")
+    mock_loop = asyncio.new_event_loop()
+    mock_get_loop.return_value = mock_loop
 
-        with patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.new_event_loop") as mock_new_loop:
-            mock_new_loop.return_value = mock_loop
-            yield mock_loop
-            mock_loop.close()
+    mock_new_loop = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.new_event_loop")
+    mock_new_loop.return_value = mock_loop
+    yield mock_loop
+    mock_loop.close()
 
 
 # Test add_to_batch (Corrected)
 @pytest.mark.asyncio(loop_scope="module")
-async def test_add_to_batch(mock_convert_html, sample_spider):
-    es_uploader = SearchGovElasticsearch(batch_size=2)
-    mock_convert_html.return_value = {"_id": "1", "title": "Test Document"}
+async def test_add_to_batch(mocker, mock_convert_html, sample_spider):
+    test_document = {"_id": "1", "title": "Test Document"}
+    mock_update_dap_visits = mocker.patch(
+        "search_gov_crawler.elasticsearch.es_batch_upload.update_dap_visits_to_document",
+    )
+    mock_update_dap_visits.return_value = test_document
+    mock_convert_html.return_value = test_document
 
-    es_uploader.add_to_batch(response_bytes, "http://example.com/1", sample_spider, "en", "text/html")
+    es_uploader = SearchGovElasticsearch(batch_size=2)
+    es_uploader.add_to_batch(RESPONSE_BYTES, "http://example.com/1", sample_spider, "en", "text/html")
     assert len(es_uploader._current_batch) == 1
 
-    es_uploader.add_to_batch(response_bytes, "http://example.com/2", sample_spider, "en", "text/html")
+    es_uploader.add_to_batch(RESPONSE_BYTES, "http://example.com/2", sample_spider, "en", "text/html")
     assert len(es_uploader._current_batch) == 0
 
 
@@ -101,21 +105,21 @@ async def test_batch_upload(mock_convert_html, sample_spider):  # Use pytest-asy
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_batch_upload_empty(sample_spider):
+async def test_batch_upload_empty(mocker, sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
     es_uploader._current_batch = []
-    es_uploader._batch_elasticsearch_upload = MagicMock()
+    es_uploader._batch_elasticsearch_upload = mocker.MagicMock()
     es_uploader.batch_upload(sample_spider)
     es_uploader._batch_elasticsearch_upload.assert_not_called()  # Ensure it is not called when the batch is empty
 
 
 # Test _batch_elasticsearch_upload
 @pytest.mark.asyncio(loop_scope="module")
-async def test_batch_elasticsearch_upload(mock_convert_html, mock_asyncio_loop, sample_spider):
+async def test_batch_elasticsearch_upload(mocker, mock_convert_html, mock_asyncio_loop, sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
     docs = [{"_id": "1", "title": "Test Document"}]
     mock_convert_html.return_value = docs[0]
-    es_uploader._create_actions = MagicMock()
+    es_uploader._create_actions = mocker.MagicMock()
     await es_uploader._batch_elasticsearch_upload(docs, mock_asyncio_loop, sample_spider)
     es_uploader._create_actions.assert_called_once()
 
@@ -144,24 +148,23 @@ def test_parse_es_urls_valid_urls():
     ]
 
 
-def test_get_client(search_gov_es, mock_es_client):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch", return_value=mock_es_client):
-        client = search_gov_es._get_client()
-        assert client == mock_es_client
-        assert search_gov_es._es_client == mock_es_client
+def test_get_client(mocker, search_gov_es, mock_es_client):
+    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
+    mock_es.return_value = mock_es_client
+
+    client = search_gov_es._get_client()
+    assert client == mock_es_client
+    assert search_gov_es._es_client == mock_es_client
 
 
-def test_get_client_exception(search_gov_es):
-    with (
-        patch(
-            "search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch",
-            side_effect=Exception("Test Exception"),
-        ),
-        patch("search_gov_crawler.elasticsearch.es_batch_upload.log") as mock_log,
-    ):
-        client = search_gov_es._get_client()
-        assert client is None
-        mock_log.exception.assert_called_once()
+def test_get_client_exception(mocker, search_gov_es):
+    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
+    mock_es.side_effect = Exception("Test Exception")
+    mock_log = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.log")
+
+    client = search_gov_es._get_client()
+    assert client is None
+    mock_log.exception.assert_called_once()
 
 
 def test_create_actions(search_gov_es):
@@ -173,28 +176,25 @@ def test_create_actions(search_gov_es):
     ]
 
 
-@pytest.mark.asyncio()
-async def test_batch_elasticsearch_upload_error(search_gov_es, sample_spider, mock_es_client):
-    with (
-        patch(
-            "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
-            return_value=mock_es_client,
-        ),
-        patch(
-            "search_gov_crawler.elasticsearch.es_batch_upload.helpers.bulk",
-            return_value=(49, [{"error": "Test Error"}]),
-        ),
-    ):
-        docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
-        loop = asyncio.get_event_loop()
-        await search_gov_es._batch_elasticsearch_upload(docs, loop, sample_spider)
-        sample_spider.logger.error.assert_called_once()  # logged errors from bulk_upload
-        sample_spider.logger.exception.assert_not_called()  # did not log and exception
+@pytest.mark.asyncio
+async def test_batch_elasticsearch_upload_error(mocker, search_gov_es, sample_spider, mock_es_client):
+    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client")
+    mock_es.return_value = mock_es_client
+
+    mock_bulk = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.bulk")
+    mock_bulk.return_value = (49, [{"error": "Test Error"}])
+
+    docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
+    loop = asyncio.get_event_loop()
+    await search_gov_es._batch_elasticsearch_upload(docs, loop, sample_spider)
+    sample_spider.logger.error.assert_called_once()  # logged errors from bulk_upload
+    sample_spider.logger.exception.assert_not_called()  # did not log and exception
 
 
-def test_client_property(search_gov_es, mock_es_client):
-    with patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch", return_value=mock_es_client):
-        assert search_gov_es.client == mock_es_client
+def test_client_property(mocker, search_gov_es, mock_es_client):
+    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
+    mock_es.return_value = mock_es_client
+    assert search_gov_es.client == mock_es_client
 
 
 def test_index_name_property(search_gov_es):

--- a/tests/search_gov_spiders/test_encoding.py
+++ b/tests/search_gov_spiders/test_encoding.py
@@ -1,22 +1,49 @@
+import pytest
+
 from search_gov_crawler.search_gov_spiders.helpers.encoding import decode_http_response, detect_encoding
 
-def test_detect_encoding():
-    some_str_bytes = "This is UTF-8".encode("utf-8")
-    assert detect_encoding(some_str_bytes) == "ASCII" # subset of utf-8
-    assert detect_encoding(b"") == None
+
+@pytest.mark.parametrize(("input_str", "encoding"), [(b"", None), (b"This is UTF-8", "ASCII")])
+def test_detect_encoding(input_str, encoding):
+    assert detect_encoding(input_str) == encoding
+
+
+def test_detect_encoding_viscii(mocker):
+    mock_detect = mocker.patch("cchardet.detect")
+    mock_detect.return_value.get.return_value = "VISCII"
+    assert detect_encoding("Đánh Tiếng Việt".encode()) == "cp1258"
+
 
 def test_decode_http_response_utf8():
     response_bytes = b"This is a UTF-8 string"
     decoded_string = decode_http_response(response_bytes)
     assert decoded_string == "This is a UTF-8 string"
 
+
 def test_decode_http_response_non_utf8():
     response_bytes = b"\xc2\xa0This is not UTF-8"  # Example non-UTF-8
     decoded_string = decode_http_response(response_bytes)
     # Check if it decodes with detected encoding or falls back to string representation
-    assert "This is not UTF-8" in decoded_string or repr(response_bytes) == decoded_string  # Allows for either decode or fallback
+    assert (
+        "This is not UTF-8" in decoded_string or repr(response_bytes) == decoded_string
+    )  # Allows for either decode or fallback
+
 
 def test_decode_http_response_empty():
     response_bytes = b""
     decoded_string = decode_http_response(response_bytes)
     assert decoded_string == ""
+
+
+def test_decode_unicode_error_from_decode():
+    response_bytes = b"\x80abc"
+    decoded_string = decode_http_response(response_bytes)
+    assert decoded_string == response_bytes.decode("WINDOWS-1252")
+
+
+def test_decode_unicode_error_from_both_decodes(mocker):
+    response_bytes = b"\x80abc"
+    mock_detect = mocker.patch("cchardet.detect")
+    mock_detect.return_value.get.return_value = "UTF-8"
+    decoded_string = decode_http_response(response_bytes)
+    assert decoded_string == str(response_bytes)

--- a/tests/search_gov_spiders/test_full_crawl.py
+++ b/tests/search_gov_spiders/test_full_crawl.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from scrapy.crawler import CrawlerProcess
 
+import search_gov_crawler.search_gov_spiders.helpers.domain_spider as helpers
 from search_gov_crawler.search_gov_spiders.job_state.scheduler import disable_redis_job_state
 from search_gov_crawler.search_gov_spiders.spiders.domain_spider import DomainSpider
 from search_gov_crawler.search_gov_spiders.spiders.domain_spider_js import (
@@ -152,7 +153,7 @@ def test_full_crawl(mock_scrapy_settings, monkeypatch, spider, use_dedup, crawl_
             "search_gov_crawler.search_gov_spiders.pipelines.SearchGovSpidersPipeline.__init__",
             mock_init,
         )
-
+        monkeypatch.setattr(helpers, "get_domain_visits", lambda _: {})
         mock_scrapy_settings.set("FEEDS", {output_file.name: {"format": "json"}})
 
         process = CrawlerProcess(mock_scrapy_settings, install_root_handler=False)

--- a/tests/search_gov_spiders/test_i14y_helper.py
+++ b/tests/search_gov_spiders/test_i14y_helper.py
@@ -153,6 +153,11 @@ def test_summarize_text_unsupported_stopwords(caplog):
             {"field1": "value1", "domain_name": "example.com", "dap_domain_visits_count": 10},
         ),
         (
+            {"field1": "value1", "domain_name": "www.example.com"},
+            10,
+            {"field1": "value1", "domain_name": "www.example.com", "dap_domain_visits_count": 10},
+        ),
+        (
             {"field1": "value1", "domain_name": "missing.example.com"},
             None,
             {"field1": "value1", "domain_name": "missing.example.com"},

--- a/tests/search_gov_spiders/test_i14y_helper.py
+++ b/tests/search_gov_spiders/test_i14y_helper.py
@@ -1,11 +1,12 @@
 import pytest
-
 from nltk.corpus import stopwords
+
 from search_gov_crawler.elasticsearch.i14y_helper import (
     detect_lang,
     parse_date_safely,
     separate_file_name,
     summarize_text,
+    update_dap_visits_to_document,
 )
 
 
@@ -130,11 +131,35 @@ def test_summarize_text(text, url, lang_code, summary, keyword):
 
 
 def test_summarize_text_unsupported_stopwords(caplog):
+    error_msg = (
+        "Unsupported Language. Error when parsing https://example.com Missing "
+        "Stopwords File: No such file or directory: "
+    )
+
     with caplog.at_level("WARNING"):
         results = summarize_text("This is a test for missing stopwork", "https://example.com", "ko")
 
     assert results == (None, None)
-    assert (
-        f"Unsupported Language. Error when parsing https://example.com Missing Stopwords File: No such file or directory: '{stopwords._root.path}/korean'"
-        in caplog.messages
-    )
+    assert f"{error_msg}'{stopwords._root.path}/korean'" in caplog.messages
+
+
+@pytest.mark.parametrize(
+    ("input_doc", "domain_visits", "output_doc"),
+    [
+        ({"field1": "value1"}, None, {"field1": "value1"}),
+        (
+            {"field1": "value1", "domain_name": "example.com"},
+            10,
+            {"field1": "value1", "domain_name": "example.com", "dap_domain_visits_count": 10},
+        ),
+        (
+            {"field1": "value1", "domain_name": "missing.example.com"},
+            None,
+            {"field1": "value1", "domain_name": "missing.example.com"},
+        ),
+    ],
+)
+def test_update_dap_visits_to_document(input_doc, domain_visits, output_doc, mocker):
+    spider = mocker.Mock()
+    spider.domain_visits.get.return_value = domain_visits
+    assert update_dap_visits_to_document(input_doc, spider) == output_doc


### PR DESCRIPTION
## Summary
- Added functionality so that the `dap_domain_visits_count` field on ES documents produced by spider contain either a 0 or a seven day average of the visits data extracted from DAP.
  - Updated existing `get_avg_daily_visits_by_domain` to match logic discussed in the dev channel, use pipelines, and explicitly decode responses.
  - In spider `__init__`, added helper function `get_domain_visits` that retrieves all domain and sub-domain data for all values in the `allowed_domains`, e.g. for a spider crawl of `gsa.gov` this will contain DAP records for `gsa.gov`, `a.gsa.gov`, `b.gsa.gov`, etc...
  - Added default values of 0 to `dap_domain_visits_count` during document creation.
  - In the `add_to_batch` method of `SearchGovElasticsearch`, added a function `update_dap_visits_to_document` that updates the documents after doing a lookup to the data retrieved during `__init__` based on the `domain_name` value in the document.
- Also removed the functionality to disable PDFs, since I don't think we are planning on doing that any more.
- Updated a bunch of tests and added test coverage where is was easy to do so.

### Testing
- Run DAP extractor `python search_gov_crawler/dap_extractor.py --days-back 14 --max-age 28 --run-now`
- Delete local searchelastic index
- Create new local searchelastic index (if you want to easily search by domain_name you should do so by using the customized settings and mappings we have in the repo but its not required for this story.)
- Run a spider job for one of the domains captured in the DAP data and assess the results.
- I tested with fac.gov
```
scrapy crawl domain_spider \
    -a allowed_domains=fac.gov \
    -a start_urls="https://www.fac.gov" \
    -a output_target=elasticsearch \
    -a depth_limit=8
```
- Verify that documents loaded into elasticsearch match a query like `GET /searchgov-spider/_search
{ "query": { "term": { "domain_name": { "value": "fac.gov" } } } }` have expected values for `dap_domain_visits_count`
  - For `domain_name` values of `www.fac.gov` there should be a value matching the last seven days average in the dap_visits:fac.gov` redis key.
  - For `domain_name` values of 'support.fac.gov` there should be a 0 value because there is not a `dap_visits:support.fac.gov`

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [X] You have specified at least one "Reviewer".
