### PR TITLE
SRCH-6100: Fixed elasticsearch batch threading on upload

### DIFF
--- a/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
@@ -23,6 +23,8 @@ from search_gov_crawler.search_gov_spiders.helpers import content
 
 log = logging.getLogger(__name__)
 
+# Suppress all pypdf debug/warning messages
+logging.getLogger("pypdf._reader").setLevel(logging.ERROR)
 
 def add_title_and_filename(key: str, title_key: str, doc: dict):
     """

--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -143,7 +143,6 @@ class SearchGovElasticsearch:
         self._current_batch = []
 
         actions = self._create_actions(batch, spider)
-        success_count = 0
         failure_count = 0
         failures: List[Any] = []
 
@@ -156,15 +155,13 @@ class SearchGovElasticsearch:
                 chunk_size=self._batch_size,
                 max_chunk_bytes=10 * 1024 * 1024,
             ):
-                if ok:
-                    success_count += 1
-                else:
+                if not ok:
                     failure_count += 1
                     failures.append(info)
 
-            if success_count:
-                spider.logger.info("Successfully indexed %d documents", success_count)
-            if failure_count:
+            if not failure_count:
+                    spider.logger.info("Loaded %s records to Elasticsearch!", success)
+            else:
                 spider.logger.error(
                     "Failed to index %d documents; errors: %r", failure_count, failures
                 )

--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -160,7 +160,7 @@ class SearchGovElasticsearch:
                     failures.append(info)
 
             if not failure_count:
-                    spider.logger.info("Loaded %s records to Elasticsearch!", success)
+                    spider.logger.info("Loaded %s records to Elasticsearch!", len(batch))
             else:
                 spider.logger.error(
                     "Failed to index %d documents; errors: %r", failure_count, failures

--- a/search_gov_crawler/search_gov_spiders/helpers/content.py
+++ b/search_gov_crawler/search_gov_spiders/helpers/content.py
@@ -26,7 +26,10 @@ def sanitize_text(text: str) -> Optional[str]:
     """Sanitize an entire text block by processing each line while preserving or trimming spaces."""
     if not text:
         return None
-    clean_text = text
+
+    # Convert to string to remove non-printable characters and force string type
+    text = clean_text = f"{text}"
+
     try:
         clean_text = "\n".join(
             filter(None, (clean_line(line) for line in text.splitlines()))

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -137,8 +137,8 @@ SPIDERMON_REPORT_CONTEXT = {"report_title": "Spidermon File Report"}
 SPIDERMON_REPORT_FILENAME = f"{spider_start.isoformat()}_spidermon_file_report.html"
 SPIDERMON_REPORT_TEMPLATE = "results.jinja"
 
-SPIDERMON_AWS_ACCESS_KEY_ID = os.environ.get("SEARCH_AWS_ACCESS_KEY_ID")
-SPIDERMON_AWS_SECRET_ACCESS_KEY = os.environ.get("SEARCH_AWS_SECRET_ACCESS_KEY")
+SPIDERMON_AWS_ACCESS_KEY_ID = os.environ.get("SEARCH_AWS_ACCESS_KEY_ID", "none")
+SPIDERMON_AWS_SECRET_ACCESS_KEY = os.environ.get("SEARCH_AWS_SECRET_ACCESS_KEY", "none")
 SPIDERMON_AWS_REGION_NAME = "us-east-1"
 SPIDERMON_EMAIL_SUBJECT = f"{env_name} Spidermon Report".capitalize()
 SPIDERMON_EMAIL_SENDER = "search@support.digitalgov.gov"

--- a/tests/search_gov_spiders/test_benchmark.py
+++ b/tests/search_gov_spiders/test_benchmark.py
@@ -98,7 +98,7 @@ class MockScheduler:
 
 def test_benchmark_from_args(caplog, monkeypatch, mock_es_client):
     with patch(
-        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch.client",
         return_value=mock_es_client,
     ):
         monkeypatch.setattr(time, "sleep", lambda x: True)
@@ -126,7 +126,7 @@ def test_benchmark_from_args(caplog, monkeypatch, mock_es_client):
 
 def test_benchmark_from_file(caplog, monkeypatch, mock_es_client):
     with patch(
-        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+        "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch.client",
         return_value=mock_es_client,
     ):
         monkeypatch.setattr(time, "sleep", lambda x: True)

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -1,11 +1,9 @@
-import asyncio
-
 import pytest
 from elasticsearch import Elasticsearch
 
 from search_gov_crawler.elasticsearch.es_batch_upload import SearchGovElasticsearch
 
-HTML_CONTNET = """
+HTML_CONTENT = """
     <html lang="en">
     <head>
         <title>Test Article Title</title>
@@ -21,8 +19,7 @@ HTML_CONTNET = """
     </html>
 """
 
-RESPONSE_BYTES = HTML_CONTNET.encode()
-
+RESPONSE_BYTES = HTML_CONTENT.encode()
 
 @pytest.fixture(name="sample_spider")
 def fixture_sample_spider(mocker):
@@ -64,21 +61,7 @@ def fixture_mock_convert_html(mocker):
     return mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.convert_html")
 
 
-@pytest.fixture(name="mock_asyncio_loop")
-def fixture_mock_asyncio_loop(mocker):
-    mock_get_loop = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.get_event_loop")
-    mock_loop = asyncio.new_event_loop()
-    mock_get_loop.return_value = mock_loop
-
-    mock_new_loop = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.asyncio.new_event_loop")
-    mock_new_loop.return_value = mock_loop
-    yield mock_loop
-    mock_loop.close()
-
-
-# Test add_to_batch (Corrected)
-@pytest.mark.asyncio(loop_scope="module")
-async def test_add_to_batch(mocker, mock_convert_html, sample_spider):
+def test_add_to_batch(mocker, mock_convert_html, sample_spider):
     test_document = {"_id": "1", "title": "Test Document"}
     mock_update_dap_visits = mocker.patch(
         "search_gov_crawler.elasticsearch.es_batch_upload.update_dap_visits_to_document",
@@ -87,15 +70,18 @@ async def test_add_to_batch(mocker, mock_convert_html, sample_spider):
     mock_convert_html.return_value = test_document
 
     es_uploader = SearchGovElasticsearch(batch_size=2)
+    es_uploader.batch_upload = mocker.MagicMock()
+
     es_uploader.add_to_batch(RESPONSE_BYTES, "http://example.com/1", sample_spider, "en", "text/html")
     assert len(es_uploader._current_batch) == 1
+    es_uploader.batch_upload.assert_not_called()
 
     es_uploader.add_to_batch(RESPONSE_BYTES, "http://example.com/2", sample_spider, "en", "text/html")
-    assert len(es_uploader._current_batch) == 0
+    assert len(es_uploader._current_batch) == 2
+    es_uploader.batch_upload.assert_called_once_with(sample_spider)
 
 
-@pytest.mark.asyncio(loop_scope="module")
-async def test_batch_upload(mock_convert_html, sample_spider):  # Use pytest-asyncio's event loop
+def test_batch_upload(mock_convert_html, sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
     mock_convert_html.return_value = {"_id": "1", "title": "Test Document"}
     es_uploader._current_batch = [{"_id": "1", "title": "Test Document"}, {"_id": "2", "title": "Test Document"}]
@@ -104,24 +90,11 @@ async def test_batch_upload(mock_convert_html, sample_spider):  # Use pytest-asy
     assert len(es_uploader._current_batch) == 0
 
 
-@pytest.mark.asyncio(loop_scope="module")
-async def test_batch_upload_empty(mocker, sample_spider):
+def test_batch_upload_empty(sample_spider):
     es_uploader = SearchGovElasticsearch(batch_size=2)
     es_uploader._current_batch = []
-    es_uploader._batch_elasticsearch_upload = mocker.MagicMock()
     es_uploader.batch_upload(sample_spider)
-    es_uploader._batch_elasticsearch_upload.assert_not_called()  # Ensure it is not called when the batch is empty
-
-
-# Test _batch_elasticsearch_upload
-@pytest.mark.asyncio(loop_scope="module")
-async def test_batch_elasticsearch_upload(mocker, mock_convert_html, mock_asyncio_loop, sample_spider):
-    es_uploader = SearchGovElasticsearch(batch_size=2)
-    docs = [{"_id": "1", "title": "Test Document"}]
-    mock_convert_html.return_value = docs[0]
-    es_uploader._create_actions = mocker.MagicMock()
-    await es_uploader._batch_elasticsearch_upload(docs, mock_asyncio_loop, sample_spider)
-    es_uploader._create_actions.assert_called_once()
+    # No assertion needed as batch_upload should do nothing when batch is empty
 
 
 def test_add_to_batch_no_doc(mock_convert_html, sample_spider):
@@ -134,9 +107,8 @@ def test_add_to_batch_no_doc(mock_convert_html, sample_spider):
 
 def test_parse_es_urls_invalid_url():
     es_uploader = SearchGovElasticsearch()
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Invalid Elasticsearch URL"):
         es_uploader._parse_es_urls("invalid-url")
-    assert "Invalid Elasticsearch URL" in str(excinfo.value)
 
 
 def test_parse_es_urls_valid_urls():
@@ -148,23 +120,21 @@ def test_parse_es_urls_valid_urls():
     ]
 
 
-def test_get_client(mocker, search_gov_es, mock_es_client):
+def test_client_property(mocker, search_gov_es, mock_es_client):
     mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
     mock_es.return_value = mock_es_client
 
-    client = search_gov_es._get_client()
+    client = search_gov_es.client
     assert client == mock_es_client
     assert search_gov_es._es_client == mock_es_client
 
 
-def test_get_client_exception(mocker, search_gov_es):
+def test_client_property_exception(mocker, search_gov_es):
     mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
     mock_es.side_effect = Exception("Test Exception")
-    mock_log = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.log")
 
-    client = search_gov_es._get_client()
-    assert client is None
-    mock_log.exception.assert_called_once()
+    with pytest.raises(Exception, match="Test Exception"):
+        _ = search_gov_es.client
 
 
 def test_create_actions(search_gov_es):
@@ -176,25 +146,25 @@ def test_create_actions(search_gov_es):
     ]
 
 
-@pytest.mark.asyncio
-async def test_batch_elasticsearch_upload_error(mocker, search_gov_es, sample_spider, mock_es_client):
-    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client")
-    mock_es.return_value = mock_es_client
+def test_batch_upload_with_errors(mocker, search_gov_es, sample_spider):
+    mock_bulk = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.parallel_bulk")
+    mock_bulk.return_value = iter([(False, {"error": "Test Error"}), (True, None)])
 
-    mock_bulk = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.bulk")
-    mock_bulk.return_value = (49, [{"error": "Test Error"}])
-
-    docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
-    loop = asyncio.get_event_loop()
-    await search_gov_es._batch_elasticsearch_upload(docs, loop, sample_spider)
-    sample_spider.logger.error.assert_called_once()  # logged errors from bulk_upload
-    sample_spider.logger.exception.assert_not_called()  # did not log and exception
+    search_gov_es._current_batch = [{"_id": "1", "title": "Test Document"}, {"_id": "2", "title": "Test Document"}]
+    search_gov_es.batch_upload(sample_spider)
+    sample_spider.logger.error.assert_called_once_with(
+        "Failed to index %d documents; errors: %r", 1, [{"error": "Test Error"}]
+    )
+    sample_spider.logger.info.assert_called_once_with("Successfully indexed %d documents", 1)
 
 
-def test_client_property(mocker, search_gov_es, mock_es_client):
-    mock_es = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.Elasticsearch")
-    mock_es.return_value = mock_es_client
-    assert search_gov_es.client == mock_es_client
+def test_batch_upload_exception(mocker, search_gov_es, sample_spider):
+    mock_bulk = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.parallel_bulk")
+    mock_bulk.side_effect = Exception("Bulk upload failed")
+
+    search_gov_es._current_batch = [{"_id": "1", "title": "Test Document"}]
+    search_gov_es.batch_upload(sample_spider)
+    sample_spider.logger.exception.assert_called_once_with("Bulk upload to ES failed: %s", mocker.ANY)
 
 
 def test_index_name_property(search_gov_es):

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -137,9 +137,9 @@ def test_client_property_exception(mocker, search_gov_es):
         _ = search_gov_es.client
 
 
-def test_create_actions(search_gov_es):
+def test_create_actions(search_gov_es, sample_spider):
     docs = [{"_id": "1", "content": "test1"}, {"_id": "2", "content": "test2"}]
-    actions = search_gov_es._create_actions(docs)
+    actions = search_gov_es._create_actions(docs, sample_spider)
     assert actions == [
         {"_index": "test_index", "_id": "1", "_source": {"content": "test1"}},
         {"_index": "test_index", "_id": "2", "_source": {"content": "test2"}},

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -155,7 +155,6 @@ def test_batch_upload_with_errors(mocker, search_gov_es, sample_spider):
     sample_spider.logger.error.assert_called_once_with(
         "Failed to index %d documents; errors: %r", 1, [{"error": "Test Error"}]
     )
-    sample_spider.logger.info.assert_called_once_with("Successfully indexed %d documents", 1)
 
 
 def test_batch_upload_exception(mocker, search_gov_es, sample_spider):

--- a/tests/search_gov_spiders/test_scrapy_scheduler.py
+++ b/tests/search_gov_spiders/test_scrapy_scheduler.py
@@ -157,7 +157,7 @@ def test_start_scrapy_scheduler(caplog, monkeypatch, crawl_sites_test_file, mock
     with (
         caplog.at_level("INFO"),
         patch(
-            "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch._get_client",
+            "search_gov_crawler.elasticsearch.es_batch_upload.SearchGovElasticsearch.client",
             return_value=mock_es_client,
         ),
         patch("search_gov_crawler.scrapy_scheduler.SpiderRedisJobStore", return_value=mock_jobstore),


### PR DESCRIPTION
This fixes the batch uploading by making it a sync type of operation. The elasticsearch python client still breaks the request up and sends it in parallel, so the speed trade of is not to significant. This is a race condition type of bug and it might randomly work or fail depending on batch size.

Here is a way to test it:
```bash
# On main/old code this should break (without error) and not send the document to Elasticsearch:
scrapy crawl domain_spider \
	-a allowed_domains=govinfo.gov \
	-a start_urls="https://www.govinfo.gov/media/100-2se.pdf" \
	-a output_target=elasticsearch \
	-a depth_limit=1 \
	-a prevent_follow=True

# This should work and the document will get indexed in Elasticsearch:
scrapy crawl domain_spider \
	-a allowed_domains=govinfo.gov \
	-a start_urls="https://space-geodesy.nasa.gov/docs/2012/LRO-LR_xpondrWG_Nov2012_v2.pdf" \
	-a output_target=elasticsearch \
	-a depth_limit=1 \
	-a prevent_follow=True
```

With this fix both should work now and if something fails there's more error coverage

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
