### PR TITLE
SRCH-6008-6009 update parse if date to correctly accept more types

### DIFF
--- a/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
+++ b/search_gov_crawler/elasticsearch/convert_pdf_i14y.py
@@ -1,8 +1,8 @@
-import re
 import logging
-
-from datetime import datetime, timedelta
+import re
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
+from typing import Any
 
 from pypdf import PageObject, PdfReader
 from pypdf.generic import IndirectObject
@@ -88,6 +88,7 @@ def convert_pdf(response_bytes: bytes, url: str, response_language: str = None):
     reader = PdfReader(pdf_stream)
 
     if reader.is_encrypted:
+        log.warning("PDF is encrypted, cannot parse: %s", url)
         return None
 
     meta_values = get_pdf_meta(reader)
@@ -189,10 +190,15 @@ def get_pdf_meta(reader: PdfReader) -> dict:
     return clean_metadata
 
 
-def parse_if_date(value, apply_tz_offset: bool = False):
+def parse_if_date(value, apply_tz_offset: bool = False) -> Any:
     """
     Parses a value as date if matched the conventional pdf/exif date format. If parsing fails,
     returns the original value
+
+    Examples of str date format:
+         D:20150113143419Z00'00' <---- support this!
+        "D:20191018122555-04'00'"
+        "D:20191018162538"
 
     Args:
         value: The value to parse.
@@ -200,38 +206,40 @@ def parse_if_date(value, apply_tz_offset: bool = False):
     Returns:
         A datetime.datetime object if parsing is successful, otherwise the original value.
     """
-    if not isinstance(value, str) or not value.startswith("D:"):
-        return content.sanitize_text(value)
+    if not isinstance(value, str):
+        return value
 
-    date_string = value[2:]  # Remove the "D:" prefix
+    if value.startswith("D:"):
+        date_string = value.removeprefix("D:")
 
-    """
-    Example of matched date values:
-        "D:20191018122555-04'00'"
-        "D:20191018162538"
-    """
-    match = re.match(
-        r"(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?([+-]\d{2})?'?(\d{2})?'?",
-        date_string,
-    )
+        match = re.match(
+            r"(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?([+-]\d{2})?'?(\d{2})?'?",
+            date_string,
+        )
 
-    if match:
-        year = int(match.group(1))
-        month = int(match.group(2))
-        day = int(match.group(3))
-        hour = int(match.group(4)) if match.group(4) else 0
-        minute = int(match.group(5)) if match.group(5) else 0
-        second = int(match.group(6)) if match.group(6) else 0
-        tz_hour = int(match.group(7)[:3]) if match.group(7) else 0
-        tz_minute = int(match.group(7)[4:]) if match.group(7) and len(match.group(7)) > 4 else 0
+        if match:
+            year = int(match.group(1))
+            month = int(match.group(2))
+            day = int(match.group(3))
+            hour = int(match.group(4)) if match.group(4) else 0
+            minute = int(match.group(5)) if match.group(5) else 0
+            second = int(match.group(6)) if match.group(6) else 0
+            tz_hour = int(match.group(7)) if match.group(7) else 0
+            tz_minute = int(match.group(8)) if match.group(8) else 0
 
-        try:
-            dt = datetime(year, month, day, hour, minute, second)
-            if match.group(7) and apply_tz_offset:  # handle timezone offset if matched
+            # Handle timezone offset if matched
+            if match.group(7) and apply_tz_offset:
                 tz_sign = 1 if tz_hour >= 0 else -1
-                tz_offset = timedelta(hours=tz_hour, minutes=tz_minute)
-                dt = dt - tz_sign * tz_offset
-            return dt
-        except ValueError as err:
-            raise f'Failed to parse Date value "{value}":\n{str(err)}'
+                offset = timedelta(hours=tz_hour, minutes=tz_minute * tz_sign)
+                tz = timezone(offset=offset)
+            else:
+                tz = None
+
+            try:
+                return datetime(year, month, day, hour, minute, second, tzinfo=tz)
+            except ValueError:
+                log.exception("Failed to parse date string: %s", value)
+        else:
+            log.error("Failed to parse date string: %s", value)
+
     return content.sanitize_text(value)


### PR DESCRIPTION
## Summary
- Updated the `parse_if_date` function so that it only performs is work on string values and just passes along other values.  This prevents the errors caused by trying to do string things on non-strings.

The important change is
```python
if not isinstance(value, str) or not value.startswith("D:"):
    return content.sanitize_text(value)
```
to
```python
if not isinstance(value, str):
    return value
```

because otherwise a non string value is getting passed to `santize_text` and causing issues because `str` operations are being performed in that function.

## Testing


### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
