### PR TITLE
SRCH-6010 PDF Bug

### DIFF
--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -44,9 +44,7 @@ class SearchGovElasticsearch:
         self._current_batch: List[Dict[str, Any]] = []
 
         self._env_es_hosts = es_hosts or os.getenv("ES_HOSTS", "http://localhost:9200")
-        self._env_es_index = es_index or os.getenv(
-            "SEARCHELASTIC_INDEX", "development-i14y-documents-searchgov"
-        )
+        self._env_es_index = es_index or os.getenv("SEARCHELASTIC_INDEX", "development-i14y-documents-searchgov")
         self._env_es_user = es_user or os.getenv("ES_USER", "")
         self._env_es_password = es_password or os.getenv("ES_PASSWORD", "")
         self._timeout = timeout
@@ -97,13 +95,11 @@ class SearchGovElasticsearch:
             elif content_type == "application/pdf":
                 doc = convert_pdf(response_bytes, url, response_language)
             else:
-                spider.logger.warning(
-                    "Unsupported content type %r for URL %s; skipping", content_type, url
-                )
+                spider.logger.warning("Unsupported content type %r for URL %s; skipping", content_type, url)
                 return
 
         except Exception:
-            spider.logger.exception("Failed to convert %s (type %s): %s", url, content_type)
+            spider.logger.exception("Failed to convert %s (type %s)", url, content_type)
             return
 
         if not doc:
@@ -160,14 +156,12 @@ class SearchGovElasticsearch:
                     failures.append(info)
 
             if not failure_count:
-                    spider.logger.info("Loaded %s records to Elasticsearch!", len(batch))
+                spider.logger.info("Loaded %s records to Elasticsearch!", len(batch))
             else:
-                spider.logger.error(
-                    "Failed to index %d documents; errors: %r", failure_count, failures
-                )
+                spider.logger.error("Failed to index %d documents; errors: %r", failure_count, failures)
 
-        except Exception as e:
-            spider.logger.exception("Bulk upload to ES failed: %s", e)
+        except Exception:
+            spider.logger.exception("Bulk upload to ES failed")
 
     def _parse_es_urls(self, url_string: str) -> List[Dict[str, Union[str, int]]]:
         """Parse comma-separated ES URLs into host dicts."""
@@ -176,7 +170,5 @@ class SearchGovElasticsearch:
             parsed = urlparse(raw.strip())
             if not parsed.scheme or not parsed.hostname or not parsed.port:
                 raise ValueError(f"Invalid Elasticsearch URL: {raw!r}")
-            hosts.append(
-                {"host": parsed.hostname, "port": parsed.port, "scheme": parsed.scheme}
-            )
+            hosts.append({"host": parsed.hostname, "port": parsed.port, "scheme": parsed.scheme})
         return hosts

--- a/search_gov_crawler/requirements.txt
+++ b/search_gov_crawler/requirements.txt
@@ -7,7 +7,7 @@ langdetect==1.0.9
 lxml-html-clean==0.4.1 # Required by newspaper4k, ignored by dependabot
 newspaper4k[all]==0.9.3.1 # This also installs the nltk library
 pylint==3.3.7
-pypdf==5.3.1
+pypdf==5.7.0
 pytest==8.4.1
 pytest-asyncio==1.1.0
 pytest-console-scripts==1.4.1

--- a/tests/search_gov_spiders/test_elasticsearch.py
+++ b/tests/search_gov_spiders/test_elasticsearch.py
@@ -21,6 +21,7 @@ HTML_CONTENT = """
 
 RESPONSE_BYTES = HTML_CONTENT.encode()
 
+
 @pytest.fixture(name="sample_spider")
 def fixture_sample_spider(mocker):
     """Fixture for a mock spider with a logger."""
@@ -163,7 +164,7 @@ def test_batch_upload_exception(mocker, search_gov_es, sample_spider):
 
     search_gov_es._current_batch = [{"_id": "1", "title": "Test Document"}]
     search_gov_es.batch_upload(sample_spider)
-    sample_spider.logger.exception.assert_called_once_with("Bulk upload to ES failed: %s", mocker.ANY)
+    sample_spider.logger.exception.assert_called_once_with("Bulk upload to ES failed")
 
 
 def test_index_name_property(search_gov_es):


### PR DESCRIPTION
## Summary
- Addresses error seen in production:
```
Traceback (most recent call last):
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/search_gov_crawler/search_gov_spiders/pipelines.py", line 93, in _process_es_item
    self._get_elasticsearch_client().add_to_batch(
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/search_gov_crawler/elasticsearch/es_batch_upload.py", line 44, in add_to_batch
    doc = convert_pdf(response_bytes=response_bytes, url=url, response_language=response_language)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/search_gov_crawler/elasticsearch/convert_pdf_i14y.py", line 97, in convert_pdf
    main_content, pages = get_pdf_text(reader)
                          ^^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/search_gov_crawler/elasticsearch/convert_pdf_i14y.py", line 165, in get_pdf_text
    page_text = page.extract_text()
                ^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/_page.py", line 2378, in extract_text
    return self._extract_text(
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/_page.py", line 2073, in _extract_text
    for operands, operator in content.operations:
                              ^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/generic/_data_structures.py", line 1432, in operations
    self._parse_content_stream(BytesIO(self._data))
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/generic/_data_structures.py", line 1311, in _parse_content_stream
    ii = self._read_inline_image(stream)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/generic/_data_structures.py", line 1383, in _read_inline_image
    data = extract_inline_default(stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/codedeploy-agent/deployment-root/a0ccbb6c-4ba1-41e7-89e4-d9031fd23edf/d-X2V6KZJOD/deployment-archive/venv/lib/python3.12/site-packages/pypdf/generic/_image_inline.py", line 201, in extract_inline_default
    raise PdfReadError("Unexpected end of stream")

```
- I investigated and found that this mostly happened with PDFs with charts and maps and things like that.  On a lark I tried upgrading the pypdf version and that seemed to fix things!
- In my testing also noticed an error with a logging line in `es_batch_upload.py`
`spider.logger.exception("Failed to convert %s (type %s): %s", url, content_type)` had three `%s` but only two values to replace them.  I think this is a remnant of removing exceptions from the messages.

### Testing

* Prior to upgrading pypdf, run this command to see the error.  Then upgrade pypdf to the version in the requirements.txt file and rerun to see that the issue no longer exists.
```
scrapy crawl domain_spider \
    -a allowed_domains=emc.ncep.noaa.gov \
    -a start_urls="https://www.emc.ncep.noaa.gov/gmb/ens/NAEFS-5th/Session_4/UnzonNAEFSusageMexico.pdf" \
    -a output_target=elasticsearch \
    -a depth_limit=1 \
    -a prevent_follow=True
```

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
