### PR TITLE
SRCH-6176: Added Opensearch indexing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
           - "spidermon*"
           - "apscheduler"
           - "elasticsearch"
+          - "opensearch-py"
           - "redis"
           - "newspaper4k*"
           - "cchardet"

--- a/docker-compose.opensearch.yml
+++ b/docker-compose.opensearch.yml
@@ -1,0 +1,55 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.15.0
+    env_file:
+      - .env
+    container_name: opensearch
+    restart: on-failure
+    tty: true
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true 
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+      - ./setup_docker_opensearch.sh:/setup_docker_opensearch.sh
+      - ./.env:/.env # make sure the .env file exists and is in your project root
+    post_start:
+      - command: bash -i /setup_docker_opensearch.sh
+        user: root
+        privileged: true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9300 >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    ports:
+      - 9300:9200 # Use 9300 to avoid conflict with Elasticsearch's and Opensearch's default 9200
+    networks:
+      - opensearch-net
+
+  opensearch-dashboards:
+    container_name: opensearch-dashboards
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    image: opensearchproject/opensearch-dashboards:2.15.0
+    environment:
+      - OPENSEARCH_HOSTS=["http://opensearch:9300"]
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+    ports:
+      - 5602:5601 # Use 5602 to avoid conflict with Kibana's 5601
+    networks:
+      - opensearch-net
+
+volumes:
+  opensearch-data:
+    driver: local
+
+networks:
+  opensearch-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.20
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
+    env_file:
+      - .env
     container_name: elasticsearch
     restart: on-failure
     tty: true
@@ -15,6 +17,7 @@ services:
     volumes:
       - es-data:/usr/share/elasticsearch/data
       - ./setup_docker_es.sh:/setup_docker_es.sh
+      - ./.env:/.env # make sure the .env file exists and is in your project root
     post_start:
       - command: bash -i /setup_docker_es.sh
         user: root
@@ -34,7 +37,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:7.17.20
+    image: docker.elastic.co/kibana/kibana:7.17.28
     environment:
       - ELASTICSEARCH_URL="http://elasticsearch:9200"
       - DISABLE_SECURITY_DASHBOARDS_PLUGIN="true"

--- a/opensearch_index_settings.json
+++ b/opensearch_index_settings.json
@@ -1,0 +1,970 @@
+{
+    "settings": {
+        "index": {
+            "number_of_shards": "6",
+            "analysis": {
+                "filter": {
+                    "en_protected_filter": {
+                        "keywords": [
+                            "gas",
+                            "fevs"
+                        ],
+                        "type": "keyword_marker"
+                    },
+                    "fr_stem_filter": {
+                        "name": "light_french",
+                        "type": "stemmer"
+                    },
+                    "it_stem_filter": {
+                        "name": "light_italian",
+                        "type": "stemmer"
+                    },
+                    "bn_stem_filter": {
+                        "name": "bengali",
+                        "type": "stemmer"
+                    },
+                    "de_stem_filter": {
+                        "name": "light_german",
+                        "type": "stemmer"
+                    },
+                    "en_stem_filter": {
+                        "name": "english",
+                        "type": "stemmer"
+                    },
+                    "es_protected_filter": {
+                        "keywords": [
+                            "ronaldo"
+                        ],
+                        "type": "keyword_marker"
+                    },
+                    "bigrams_filter": {
+                        "type": "shingle"
+                    },
+                    "hi_stem_filter": {
+                        "name": "hindi",
+                        "type": "stemmer"
+                    },
+                    "fi_stem_filter": {
+                        "name": "finnish",
+                        "type": "stemmer"
+                    },
+                    "ja_pos_filter": {
+                        "type": "kuromoji_part_of_speech",
+                        "stoptags": [
+                            "\u52a9\u8a5e-\u683c\u52a9\u8a5e-\u4e00\u822c",
+                            "\u52a9\u8a5e-\u7d42\u52a9\u8a5e"
+                        ]
+                    },
+                    "es_stem_filter": {
+                        "name": "light_spanish",
+                        "type": "stemmer"
+                    },
+                    "hu_stem_filter": {
+                        "name": "hungarian",
+                        "type": "stemmer"
+                    },
+                    "pt_stem_filter": {
+                        "name": "light_portuguese",
+                        "type": "stemmer"
+                    },
+                    "ru_stem_filter": {
+                        "name": "russian",
+                        "type": "stemmer"
+                    },
+                    "sv_stem_filter": {
+                        "name": "swedish",
+                        "type": "stemmer"
+                    },
+                    "en_synonym": {
+                        "type": "synonym",
+                        "synonyms": [
+                            "gas, petrol"
+                        ]
+                    }
+                },
+                "char_filter": {
+                    "quotes": {
+                        "type": "mapping",
+                        "mappings": [
+                            "\u0091=>\u0027",
+                            "\u0092=>\u0027",
+                            "\u2018=>\u0027",
+                            "\u2019=>\u0027",
+                            "\u201B=>\u0027"
+                        ]
+                    }
+                },
+                "analyzer": {
+                    "de_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "de_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "en_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "en_protected_filter",
+                            "en_stem_filter",
+                            "en_synonym",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "ko_analyzer": {
+                        "filter": [],
+                        "type": "cjk"
+                    },
+                    "bn_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "bn_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "sv_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "sv_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "pt_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "pt_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "fr_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "elision",
+                            "fr_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "it_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "it_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "default": {
+                        "filter": [
+                            "icu_normalizer",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "url_path_analyzer": {
+                        "filter": "lowercase",
+                        "type": "custom",
+                        "tokenizer": "url_path_tokenizer"
+                    },
+                    "ja_analyzer": {
+                        "filter": [
+                            "kuromoji_baseform",
+                            "ja_pos_filter",
+                            "icu_normalizer",
+                            "icu_folding",
+                            "cjk_width"
+                        ],
+                        "char_filter": [
+                            "html_strip"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "kuromoji_tokenizer"
+                    },
+                    "fi_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "fi_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "hu_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "hu_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "domain_name_analyzer": {
+                        "filter": "lowercase",
+                        "type": "custom",
+                        "tokenizer": "domain_name_tokenizer"
+                    },
+                    "hi_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "hi_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "es_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "es_protected_filter",
+                            "es_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "bigrams_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "icu_folding",
+                            "bigrams_filter"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "ru_analyzer": {
+                        "filter": [
+                            "icu_normalizer",
+                            "ru_stem_filter",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip",
+                            "quotes"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "icu_tokenizer"
+                    },
+                    "zh_analyzer": {
+                        "filter": [
+                            "smartcn_word",
+                            "icu_normalizer",
+                            "icu_folding"
+                        ],
+                        "char_filter": [
+                            "html_strip"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "smartcn_sentence"
+                    }
+                },
+                "tokenizer": {
+                    "kuromoji": {
+                        "mode": "search",
+                        "type": "kuromoji_tokenizer",
+                        "char_filter": [
+                            "html_strip"
+                        ]
+                    },
+                    "domain_name_tokenizer": {
+                        "reverse": "true",
+                        "type": "PathHierarchy",
+                        "delimiter": "."
+                    },
+                    "url_path_tokenizer": {
+                        "type": "PathHierarchy"
+                    }
+                }
+            },
+            "number_of_replicas": "1"
+        }
+    },
+    "mappings": {
+        "dynamic_templates": [
+            {
+                "bn": {
+                    "match": "*_bn",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "bn_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "de": {
+                    "match": "*_de",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "de_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "en": {
+                    "match": "*_en",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "en_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "es": {
+                    "match": "*_es",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "es_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "fi": {
+                    "match": "*_fi",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "fi_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "fr": {
+                    "match": "*_fr",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "fr_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "hi": {
+                    "match": "*_hi",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "hi_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "hu": {
+                    "match": "*_hu",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "hu_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "it": {
+                    "match": "*_it",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "it_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "ja": {
+                    "match": "*_ja",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "ja_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "ko": {
+                    "match": "*_ko",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "ko_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "pt": {
+                    "match": "*_pt",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "pt_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "ru": {
+                    "match": "*_ru",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "ru_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "sv": {
+                    "match": "*_sv",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "sv_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "zh": {
+                    "match": "*_zh",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "zh_analyzer",
+                        "copy_to": "bigrams",
+                        "term_vector": "with_positions_offsets",
+                        "type": "text"
+                    }
+                }
+            },
+            {
+                "string_fields": {
+                    "match": "*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "index": true,
+                        "type": "text"
+                    }
+                }
+            }
+        ],
+        "properties": {
+            "audience": {
+                "type": "keyword"
+            },
+            "basename": {
+                "type": "text"
+            },
+            "bigrams": {
+                "type": "text",
+                "analyzer": "bigrams_analyzer"
+            },
+            "changed": {
+                "type": "date"
+            },
+            "click_count": {
+                "type": "integer"
+            },
+            "content": {
+                "type": "text"
+            },
+            "content_ar": {
+                "type": "text"
+            },
+            "content_ca": {
+                "type": "text"
+            },
+            "content_cs": {
+                "type": "text"
+            },
+            "content_de": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "de_analyzer"
+            },
+            "content_en": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "en_analyzer"
+            },
+            "content_es": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "es_analyzer"
+            },
+            "content_fa": {
+                "type": "text"
+            },
+            "content_fr": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "fr_analyzer"
+            },
+            "content_he": {
+                "type": "text"
+            },
+            "content_hy": {
+                "type": "text"
+            },
+            "content_id": {
+                "type": "text"
+            },
+            "content_it": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "it_analyzer"
+            },
+            "content_ko": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ko_analyzer"
+            },
+            "content_mk": {
+                "type": "text"
+            },
+            "content_pl": {
+                "type": "text"
+            },
+            "content_ps": {
+                "type": "text"
+            },
+            "content_pt": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "pt_analyzer"
+            },
+            "content_ru": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ru_analyzer"
+            },
+            "content_so": {
+                "type": "text"
+            },
+            "content_sw": {
+                "type": "text"
+            },
+            "content_tr": {
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_uk": {
+                "type": "text"
+            },
+            "content_ur": {
+                "type": "text"
+            },
+            "content_uz": {
+                "type": "text"
+            },
+            "content_vi": {
+                "type": "text"
+            },
+            "created": {
+                "type": "date"
+            },
+            "created_at": {
+                "type": "date"
+            },
+            "description": {
+                "type": "text"
+            },
+            "description_ar": {
+                "type": "text"
+            },
+            "description_ca": {
+                "type": "text"
+            },
+            "description_cs": {
+                "type": "text"
+            },
+            "description_de": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "de_analyzer"
+            },
+            "description_en": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "en_analyzer"
+            },
+            "description_es": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "es_analyzer"
+            },
+            "description_fa": {
+                "type": "text"
+            },
+            "description_fr": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "fr_analyzer"
+            },
+            "description_he": {
+                "type": "text"
+            },
+            "description_hy": {
+                "type": "text"
+            },
+            "description_id": {
+                "type": "text"
+            },
+            "description_it": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "it_analyzer"
+            },
+            "description_ko": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ko_analyzer"
+            },
+            "description_mk": {
+                "type": "text"
+            },
+            "description_pl": {
+                "type": "text"
+            },
+            "description_ps": {
+                "type": "text"
+            },
+            "description_pt": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "pt_analyzer"
+            },
+            "description_ru": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ru_analyzer"
+            },
+            "description_so": {
+                "type": "text"
+            },
+            "description_sw": {
+                "type": "text"
+            },
+            "description_tr": {
+                "type": "text"
+            },
+            "description_uk": {
+                "type": "text"
+            },
+            "description_ur": {
+                "type": "text"
+            },
+            "description_uz": {
+                "type": "text"
+            },
+            "description_vi": {
+                "type": "text"
+            },
+            "document_id": {
+                "type": "keyword"
+            },
+            "domain_name": {
+                "type": "text",
+                "analyzer": "domain_name_analyzer"
+            },
+            "extension": {
+                "type": "keyword"
+            },
+            "id": {
+                "type": "text"
+            },
+            "language": {
+                "type": "keyword"
+            },
+            "mime_type": {
+                "type": "keyword"
+            },
+            "path": {
+                "type": "keyword"
+            },
+            "promote": {
+                "type": "boolean"
+            },
+            "searchgov_custom1": {
+                "type": "keyword"
+            },
+            "searchgov_custom2": {
+                "type": "keyword"
+            },
+            "searchgov_custom3": {
+                "type": "keyword"
+            },
+            "tags": {
+                "type": "keyword"
+            },
+            "thumbnail_url": {
+                "type": "keyword"
+            },
+            "title": {
+                "type": "text"
+            },
+            "title_ar": {
+                "type": "text"
+            },
+            "title_ca": {
+                "type": "text"
+            },
+            "title_cs": {
+                "type": "text"
+            },
+            "title_de": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "de_analyzer"
+            },
+            "title_en": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "en_analyzer"
+            },
+            "title_es": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "es_analyzer"
+            },
+            "title_fa": {
+                "type": "text"
+            },
+            "title_fr": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "fr_analyzer"
+            },
+            "title_he": {
+                "type": "text"
+            },
+            "title_hy": {
+                "type": "text"
+            },
+            "title_id": {
+                "type": "text"
+            },
+            "title_it": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "it_analyzer"
+            },
+            "title_ko": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ko_analyzer"
+            },
+            "title_mk": {
+                "type": "text"
+            },
+            "title_pl": {
+                "type": "text"
+            },
+            "title_ps": {
+                "type": "text"
+            },
+            "title_pt": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "pt_analyzer"
+            },
+            "title_ru": {
+                "type": "text",
+                "copy_to": [
+                    "bigrams"
+                ],
+                "term_vector": "with_positions_offsets",
+                "analyzer": "ru_analyzer"
+            },
+            "title_so": {
+                "type": "text"
+            },
+            "title_sw": {
+                "type": "text"
+            },
+            "title_tr": {
+                "type": "text"
+            },
+            "title_uk": {
+                "type": "text"
+            },
+            "title_ur": {
+                "type": "text"
+            },
+            "title_uz": {
+                "type": "text"
+            },
+            "title_vi": {
+                "type": "text"
+            },
+            "updated": {
+                "type": "date"
+            },
+            "updated_at": {
+                "type": "date"
+            },
+            "url_path": {
+                "type": "text",
+                "analyzer": "url_path_analyzer"
+            }
+        }
+    }
+}

--- a/search_gov_crawler/elasticsearch/es_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/es_batch_upload.py
@@ -90,9 +90,9 @@ class SearchGovElasticsearch:
         spider: SearchGovDomainSpider,
         response_language: str,
         content_type: str,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """
-        Convert a response into an i14y document and add to the batch.
+        Convert a response into an i14y document, adds it to the batch, and returns the converted i14y document.
         """
         try:
             if content_type == "text/html":
@@ -120,6 +120,8 @@ class SearchGovElasticsearch:
         self._current_batch.append(doc)
         if len(self._current_batch) >= self._batch_size:
             self.batch_upload(spider)
+
+        return doc
 
     def _create_actions(self, docs: List[Dict[str, Any]], spider: SearchGovDomainSpider) -> List[Dict[str, Any]]:
         """Build bulk actions, popping out any explicit _id fields."""

--- a/search_gov_crawler/elasticsearch/opensearch_batch_upload.py
+++ b/search_gov_crawler/elasticsearch/opensearch_batch_upload.py
@@ -1,0 +1,164 @@
+import logging
+import os
+import warnings
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
+
+from opensearchpy import OpenSearch, helpers  # pylint: disable=wrong-import-order
+
+from search_gov_crawler.search_gov_spiders.spiders import SearchGovDomainSpider
+
+# Suppress warnings from urllib3 and Opensearch
+warnings.filterwarnings("ignore", category=Warning, module="urllib3")
+warnings.filterwarnings("ignore", category=Warning, module="opensearchpy")
+
+# limit excess INFO messages from opensearch that are not tied to a spider
+logging.getLogger("opensearch").setLevel(logging.ERROR)
+
+log = logging.getLogger("search_gov_crawler.opensearch")
+
+
+class SearchGovOpensearch:
+    """Manages batching and bulk-upload of scraped documents to Opensearch."""
+
+    ENABLED = os.environ.get("OPENSEARCH_ENABLED") == "True"
+
+    def __init__(
+        self,
+        batch_size: int = 50,
+        opensearch_hosts: Optional[str] = None,
+        opensearch_index: Optional[str] = None,
+        opensearch_user: Optional[str] = None,
+        opensearch_password: Optional[str] = None,
+        timeout: int = 30,
+        max_retries: int = 3,
+    ) -> None:
+        """Initialize batch and Opensearch client parameters.
+
+        Args:
+            batch_size: number of docs to buffer before bulk upload
+            opensearch_hosts: comma-separated Opensearch URLs (e.g. "https://host1:9200,https://host2:9200")
+            opensearch_index: Opensearch index name
+            opensearch_user: Basic auth username
+            opensearch_password: Basic auth password
+            timeout: client request timeout in seconds
+            max_retries: how many times to retry on failure
+        """
+        self._batch_size = batch_size
+        self._current_batch: List[Dict[str, Any]] = []
+
+        self._env_opensearch_hosts = opensearch_hosts or os.getenv("OPENSEARCH_HOSTS", "http://localhost:9200")
+        self._env_opensearch_index = opensearch_index or os.getenv("OPENSEARCH_INDEX", "development-i14y-documents-searchgov")
+        self._env_opensearch_user = opensearch_user or os.getenv("OPENSEARCH_USER", "")
+        self._env_opensearch_password = opensearch_password or os.getenv("OPENSEARCH_PASSWORD", "")
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._opensearch_client: Optional[OpenSearch] = None
+
+        try:
+            self._parsed_hosts = self._parse_opensearch_urls(self._env_opensearch_hosts)
+        except ValueError:
+            log.exception("Environment variable OPENSEARCH_HOSTS is malformed")
+            raise
+
+    @property
+    def index_name(self) -> str:
+        """Opensearch index name."""
+        return self._env_opensearch_index
+
+    @property
+    def client(self) -> OpenSearch:
+        """Lazily initialize and return the Opensearch client."""
+        if self._opensearch_client is None:
+            self._opensearch_client = OpenSearch(
+                hosts=self._parsed_hosts,
+                http_auth=(self._env_opensearch_user, self._env_opensearch_password)
+                if self._env_opensearch_user or self._env_opensearch_password
+                else None,
+                use_ssl=any(host.get("scheme") == "https" for host in self._parsed_hosts),
+                verify_certs=False,
+                ssl_show_warn=False,
+                timeout=self._timeout,
+                max_retries=self._max_retries,
+                retry_on_timeout=True,
+            )
+        return self._opensearch_client  # type: ignore
+
+    def add_to_batch(
+        self,
+        doc: dict[str, Any] | None,
+        spider: SearchGovDomainSpider,
+    ) -> None:
+        """Add a already converted i14y document to the Opensearch batch.
+        
+        NOTE: The creation of the i14y document "doc" is done in es_batch_upload.py > add_to_batch() method.
+              We are not calling convert_html(), convert_pdf(), and etc. in this method, and they will need
+              to be added once we completely migrate to Opensearch and disable Elasticsearch
+
+        Args:
+            doc: dict The already converted i14y document
+            spider: SearchGovDomainSpider The scrapy spider
+        """
+        if not self.ENABLED or not doc:
+            return
+
+        self._current_batch.append(doc)
+        if len(self._current_batch) >= self._batch_size:
+            self.batch_upload(spider)
+
+    def _create_actions(self, docs: List[Dict[str, Any]], spider: SearchGovDomainSpider) -> List[Dict[str, Any]]:
+        """Build bulk actions, popping out any explicit _id fields."""
+        actions: List[Dict[str, Any]] = []
+        for doc in docs:
+            action: Dict[str, Any] = {"_index": self._env_opensearch_index}
+            if "_id" in doc:
+                action["_id"] = doc.pop("_id")
+            else:
+                spider.logger.error("Missing _id property in document: %s", doc)
+                continue
+            action["_source"] = doc
+            actions.append(action)
+        return actions
+
+    def batch_upload(self, spider: SearchGovDomainSpider) -> None:
+        """Send batch of documents to Opensearch via bulk API."""
+        if not self._current_batch or not self.ENABLED:
+            return
+
+        batch = self._current_batch
+        self._current_batch = []
+
+        actions = self._create_actions(batch, spider)
+        failure_count = 0
+        failures: List[Any] = []
+
+        try:
+            for ok, info in helpers.parallel_bulk(
+                client=self.client,
+                actions=actions,
+                thread_count=4,
+                queue_size=4,
+                chunk_size=self._batch_size,
+                max_chunk_bytes=10 * 1024 * 1024,
+            ):
+                if not ok:
+                    failure_count += 1
+                    failures.append(info)
+
+            if not failure_count:
+                spider.logger.info("Loaded %s records to Opensearch!", len(batch))
+            else:
+                spider.logger.error("Failed to index %d documents; errors: %r", failure_count, failures)
+
+        except Exception:
+            spider.logger.exception("Bulk upload to Opensearch failed")
+
+    def _parse_opensearch_urls(self, url_string: str) -> List[Dict[str, Union[str, int]]]:
+        """Parse comma-separated Opensearch URLs into host dicts."""
+        hosts: List[Dict[str, Union[str, int]]] = []
+        for raw in url_string.split(","):
+            parsed = urlparse(raw.strip())
+            if not parsed.scheme or not parsed.hostname or not parsed.port:
+                raise ValueError(f"Invalid Opensearch URL: {raw!r}")
+            hosts.append({"host": parsed.hostname, "port": parsed.port, "scheme": parsed.scheme})
+        return hosts

--- a/search_gov_crawler/requirements.txt
+++ b/search_gov_crawler/requirements.txt
@@ -2,6 +2,7 @@ apscheduler==3.11.0
 cchardet==2.2.0a2 # C version of chardet
 click==8.1.8
 elasticsearch==8.19.0,<9.0.0 # 9.0.0 is not compatible with elasticsearch 7
+opensearch-py==3.0.0
 freezegun==1.5.5
 langdetect==1.0.9
 lxml-html-clean==0.4.1 # Required by newspaper4k, ignored by dependabot

--- a/setup_docker_es.sh
+++ b/setup_docker_es.sh
@@ -6,8 +6,9 @@ IFS=$'\n\t'
 MAX_WAIT=120
 
 set_defaults_env() {
-    export SEARCHELASTIC_INDEX="development-i14y-documents-searchgov"
-    export ES_HOSTS="http://localhost:9200"
+    # Set default values only if they are not already defined
+    export SEARCHOPENSEARCH_INDEX="${SEARCHOPENSEARCH_INDEX:-\"development-i14y-documents-opensearch\"}"
+    export OPENSEARCH_HOSTS="${ES_HOSTS:-\"http://localhost:9200\"}"
 }
 
 wait_for_elasticsearch_health() {
@@ -63,6 +64,13 @@ restart_elasticsearch() {
 }
 
 main() {
+    # Load environment variables from .env
+    if [ -f .env ]; then
+        set -o allexport
+        source .env
+        set +o allexport
+    fi
+
     set_defaults_env
 
     if ! wait_for_elasticsearch_health; then

--- a/setup_docker_opensearch.sh
+++ b/setup_docker_opensearch.sh
@@ -1,0 +1,130 @@
+#!/bin/bash -i
+set -euo pipefail
+IFS=$'\n\t'
+
+# Set a maximum wait time (seconds) to avoid infinite loops
+MAX_WAIT=300
+
+set_defaults_env() {
+    # Set default values only if they are not already defined
+    export SEARCHOPENSEARCH_INDEX="${SEARCHOPENSEARCH_INDEX:-\"development-i14y-documents-opensearch\"}"
+    export OPENSEARCH_HOSTS="${OPENSEARCH_HOSTS:-\"http://localhost:9300\"}"
+}
+
+wait_for_opensearch_healt_old() {
+    local counter=0
+    echo "Waiting for Opensearch to be healthy..."
+    until curl -sS "${OPENSEARCH_HOSTS}/_cat/health?h=status" | grep -E -q "(green|yellow)"; do
+        if (( counter >= MAX_WAIT )); then
+            echo "Error: Opensearch did not become healthy within ${MAX_WAIT} seconds."
+            return 1
+        fi
+        sleep 1
+        ((counter++))
+    done
+    echo "Opensearch is healthy."
+    return 0
+}
+
+wait_for_opensearch_healt() {
+    local max_wait=MAX_WAIT
+    local opensearch_url=OPENSEARCH_HOSTS
+    local counter=0
+    local consecutive_failures=0
+    
+    echo "Waiting for OpenSearch to be healthy (timeout: ${max_wait}s)..."
+    
+    while (( counter < max_wait )); do
+        if status=$(curl -sS --max-time 5 "${opensearch_url}/_cat/health?h=status" 2>/dev/null); then
+            consecutive_failures=0
+            if echo "$status" | grep -E -q "^(green|yellow)$"; then
+                echo "OpenSearch is healthy (status: $(echo "$status" | tr -d '\n'))."
+                return 0
+            else
+                echo "OpenSearch responding but not healthy yet (status: $(echo "$status" | tr -d '\n'))"
+            fi
+        else
+            ((consecutive_failures++))
+            if (( consecutive_failures >= 5 )); then
+                echo "Error: OpenSearch unreachable for 5 consecutive attempts"
+                return 1
+            fi
+            echo "OpenSearch not responding (attempt $((counter + 1))/${max_wait})"
+        fi
+        
+        sleep 1
+        ((counter++))
+    done
+    
+    echo "Error: OpenSearch did not become healthy within ${max_wait} seconds."
+    return 1
+}
+
+install_opensearch_plugins() {
+    local plugins=(analysis-kuromoji analysis-icu analysis-smartcn)
+    for plugin in "${plugins[@]}"; do
+        # Use the opensearch-plugin executable
+        if /usr/share/opensearch/bin/opensearch-plugin list | grep -q "${plugin}"; then
+            echo "Plugin ${plugin} is already installed, skipping."
+        else
+            echo "Installing plugin: ${plugin}"
+            # Use the opensearch-plugin executable
+            /usr/share/opensearch/bin/opensearch-plugin install "${plugin}"
+        fi
+    done
+}
+
+create_opensearch_index() {
+    # Check if the index already exists
+    if curl -sS --fail "${OPENSEARCH_HOSTS}/${OPENSEARCH_INDEX}" -o /dev/null 2>&1; then
+        echo "Index ${OPENSEARCH_INDEX} already exists, skipping creation."
+    else
+        echo "Creating index '${OPENSEARCH_INDEX}'..."
+        curl -X PUT "${OPENSEARCH_HOSTS}/${OPENSEARCH_INDEX}" \
+             -H "Content-Type: application/json" \
+             -d "@opensearch_index_settings.json"
+        echo "Index '${OPENSEARCH_INDEX}' created successfully."
+    fi
+    return 0
+}
+
+restart_opensearch() {
+    local pid
+    # Find the Opensearch Java process instead of the Elasticsearch one
+    pid=$(pgrep -f "org.opensearch.bootstrap.OpenSearch" || true)
+    if [ -n "$pid" ]; then
+        echo "Killing Opensearch with PID(s): ${pid} to trigger container restart."
+        sleep 10
+        kill "$pid"
+    fi
+    return 0
+}
+
+main() {
+    # Load environment variables from .env
+    if [ -f .env ]; then
+        set -o allexport
+        source .env
+        set +o allexport
+    fi
+    
+    set_defaults_env
+
+    if ! wait_for_opensearch_health; then
+        echo "Exiting due to Opensearch health check failure."
+        exit 1
+    fi
+
+    install_opensearch_plugins
+
+    # Wait again after installing plugins, as it can cause a brief restart
+    if ! wait_for_opensearch_health; then
+        echo "Exiting due to Opensearch health check failure after plugin installation."
+        exit 1
+    fi
+
+    create_opensearch_index
+    restart_opensearch
+}
+
+main "$@"

--- a/tests/search_gov_spiders/test_opensearch.py
+++ b/tests/search_gov_spiders/test_opensearch.py
@@ -1,0 +1,115 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from search_gov_crawler.elasticsearch.opensearch_batch_upload import SearchGovOpensearch
+
+@pytest.fixture
+def mock_spider():
+    spider = MagicMock()
+    spider.logger = MagicMock()
+    return spider
+
+
+@pytest.fixture
+def opensearch_instance(monkeypatch):
+    # Ensure ENABLED is True for testing
+    monkeypatch.setattr(SearchGovOpensearch, "ENABLED", True)
+    return SearchGovOpensearch(
+        batch_size=2,
+        opensearch_hosts="http://localhost:9200",
+        opensearch_index="test-index"
+    )
+
+
+def test_parse_opensearch_urls_valid(opensearch_instance):
+    urls = "http://host1:9200,https://host2:443"
+    result = opensearch_instance._parse_opensearch_urls(urls)
+    assert result == [
+        {"host": "host1", "port": 9200, "scheme": "http"},
+        {"host": "host2", "port": 443, "scheme": "https"},
+    ]
+
+
+def test_parse_opensearch_urls_invalid(opensearch_instance):
+    with pytest.raises(ValueError):
+        opensearch_instance._parse_opensearch_urls("http://badurl")
+
+
+def test_index_name_property(opensearch_instance):
+    assert opensearch_instance.index_name == "test-index"
+
+
+def test_client_lazy_init(opensearch_instance):
+    mock_client = MagicMock()
+    with patch("search_gov_crawler.elasticsearch.opensearch_batch_upload.OpenSearch", return_value=mock_client) as mock_cls:
+        client = opensearch_instance.client
+        assert client == mock_client
+        mock_cls.assert_called_once()
+        # Ensure second call reuses cached client
+        assert opensearch_instance.client is mock_client
+
+
+def test_add_to_batch_triggers_upload(opensearch_instance, mock_spider):
+    with patch.object(opensearch_instance, "batch_upload") as mock_upload:
+        doc1 = {"_id": "1", "field": "value"}
+        doc2 = {"_id": "2", "field": "value"}
+        opensearch_instance.add_to_batch(doc1, mock_spider)
+        opensearch_instance.add_to_batch(doc2, mock_spider)  # should trigger batch_upload
+        assert mock_upload.called
+
+
+def test_add_to_batch_disabled(monkeypatch, opensearch_instance, mock_spider):
+    monkeypatch.setattr(SearchGovOpensearch, "ENABLED", False)
+    with patch.object(opensearch_instance, "batch_upload") as mock_upload:
+        opensearch_instance.add_to_batch({"_id": "1", "field": "value"}, mock_spider)
+        assert not mock_upload.called
+
+
+def test__create_actions_with_and_without_id(opensearch_instance, mock_spider):
+    docs = [
+        {"_id": "123", "field": "value"},
+        {"field": "missing id"}
+    ]
+    actions = opensearch_instance._create_actions(docs, mock_spider)
+    assert actions == [{"_index": "test-index", "_id": "123", "_source": {"field": "value"}}]
+    mock_spider.logger.error.assert_called_once()
+
+
+def test_batch_upload_success(mocker, opensearch_instance, mock_spider):
+    docs = [{"_id": "1", "field": "v1"}, {"_id": "2", "field": "v2"}]
+    opensearch_instance._current_batch = docs.copy()
+
+    mock_bulk = mocker.patch("search_gov_crawler.elasticsearch.es_batch_upload.helpers.parallel_bulk")
+    mock_bulk.return_value = iter([(True, {"index": {}}), (True, {"index": {}})])
+
+    with patch("search_gov_crawler.elasticsearch.opensearch_batch_upload.helpers.parallel_bulk", return_value=mock_bulk()):
+        opensearch_instance.batch_upload(mock_spider)
+
+    mock_spider.logger.info.assert_called_once_with("Loaded %s records to Opensearch!", 2)
+
+
+def test_batch_upload_failure(opensearch_instance, mock_spider):
+    docs = [{"_id": "1", "field": "v1"}]
+    opensearch_instance._current_batch = docs.copy()
+
+    mock_bulk = [(False, {"error": "failed"})]
+    with patch("search_gov_crawler.elasticsearch.opensearch_batch_upload.helpers.parallel_bulk", return_value=mock_bulk):
+        opensearch_instance.batch_upload(mock_spider)
+
+    mock_spider.logger.error.assert_called_once()
+
+
+def test_batch_upload_exception(opensearch_instance, mock_spider):
+    docs = [{"_id": "1", "field": "v1"}]
+    opensearch_instance._current_batch = docs.copy()
+
+    with patch("search_gov_crawler.elasticsearch.opensearch_batch_upload.helpers.parallel_bulk", side_effect=Exception("boom")):
+        opensearch_instance.batch_upload(mock_spider)
+
+    mock_spider.logger.exception.assert_called_once_with("Bulk upload to Opensearch failed")
+
+
+def test_batch_upload_no_docs(opensearch_instance, mock_spider):
+    opensearch_instance._current_batch = []
+    with patch("search_gov_crawler.elasticsearch.opensearch_batch_upload.helpers.parallel_bulk") as mock_bulk:
+        opensearch_instance.batch_upload(mock_spider)
+        mock_bulk.assert_not_called()


### PR DESCRIPTION
## Summary
This pull-request adds ability to enable/disable Opensearch indexing (alongside Elasticsearch)

### Testing (locally)
1. Create (or add to existing) `.env` file the following variables:
```bash
OPENSEARCH_ENABLED="True"
OPENSEARCH_INDEX="development-i14y-documents-searchgov"
OPENSEARCH_HOSTS="http://localhost:9300"
OPENSEARCH_USER="username"
OPENSEARCH_PASSWORD="password"
```

2. Run both docker images:

This will take some time, so make sure you give it a good 3-5 minutes for both images
```bash
docker compose -f docker-compose.yml up
docker compose -f docker-compose.opensearch.yml up
```

4. Check and make sure the "i14y" document is indexed in Elasticsearch and Opensearch after running a scrapy spider:
```bash
scrapy crawl domain_spider \
    -a allowed_domains=ssa.gov \
    -a start_urls="https://www.ssa.gov" \
    -a output_target=elasticsearch \
    -a depth_limit=8
```

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [x] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [x] You have specified at least one "Reviewer".
