### PR TITLE
SRCH-6365: Fixed title parsing with pipes and hyphens (fixed commits)

### DIFF
--- a/search_gov_crawler/search_engines/convert_html_i14y.py
+++ b/search_gov_crawler/search_engines/convert_html_i14y.py
@@ -32,7 +32,7 @@ def convert_html(response_bytes: bytes, url: str, response_language: str = None)
     if not main_content:
         return None
 
-    title = article.title or article.meta_site_name or article_backup["title"] or None
+    title = article_backup["title"] or article.title or article.meta_site_name or None
     description = article.meta_description or article.summary or article_backup["description"] or None
     tags = article.tags or article.keywords or article.meta_keywords or article_backup["keywords"] or None
 

--- a/search_gov_crawler/search_engines/parse_html_scrapy.py
+++ b/search_gov_crawler/search_engines/parse_html_scrapy.py
@@ -54,6 +54,7 @@ def convert_html_scrapy(html_content: str) -> dict:
         or meta_tags["og:site_name"]
         or meta_tags["pagename"]
     )
+    return_obj["title"] = return_obj["title"].strip() if return_obj["title"] else None
     return_obj["language"] = (
         html_selector.xpath("//html/@lang").get()
         or html_selector.css("html::attr(lang)").get()


### PR DESCRIPTION
NOTE: This pull-request replaces https://github.com/GSA-TTS/searchgov-spider/pull/383

Looks like `newspaper4k` automatically "cleans" the title. Our scrapy backup html convert get's the "raw" title. I switched it to prioritized it instead and then use w/e backup is left.

Testing:
Run scrapy with any one of the examples from the ticket below and output the "final" i14y document title:
```
Example 1: 
URL: https://www.disasterassistance.gov/information/immediate-needs/evacuate-or-stay-put
<title>Business - U.S. Embassy in Paraguay - Learn about bilateral investment and trade</title>
title_en from spider doc: “[disasterassistance.gov](http://disasterassistance.gov/)”
title in serp, new or legacy display: “[disasterassistance.gov](http://disasterassistance.gov/)”

Example 2:
URL: https://py.usembassy.gov/business/
<title> Business - U.S. Embassy in Paraguay - Learn about bilateral investment and trade <title>
itle_en from spider doc: “U.S. Embassy in Paraguay”
Note: Another customer has titles with this pattern: “org name - about the page”. So, in this instance, if we made it so the split on “ - “ took the first part, then every page would be named “org name”. When websites use pipe for title as in “about the page | org name” (like [www.usa.gov](http://www.usa.gov/) does), the org name is always second, so the part we always want to exclude is second. For “ - “, it doesn’t seem consistent. I don’t think we should do a split / removal for “ - “.

Example 3:
https://www.mymoney.gov/tools 
<title> “Tools | MyMoney.gov” <title>
title_en for spider is “MyMoney.gov”.  

Example 4:
https://search.uscourts.gov/search?query=supervision&op=Search&affiliate=ilsp_uscourts if set to Search Elastic you will see issue.
title tag is Supervision | Southern District of Illinois but the document in Kibana from spider “Southern District of Illinois” for page https://www.ilsp.uscourts.gov/supervision

Example 5:
https://tts.gsa.gov/join/
<title>Join Us | Technology Transformation Services</title>
Spider title_en is just Technology Transformation Services 
Is spider making a decision based on character count or word count?

Example 6:
https://beta.ngs.noaa.gov/NAPGD2022/index.html
https://search.usa.gov/search?affiliate=beta-ngs&query=nsrs
<title>NAPGD2022 Home | Beta | National Geodetic Survey</title>
title_en : National Geodetic Survey

Example 7:
This one with hyphen not pipe
https://www.nsfgrfp.org/applicants/application-resources.html
<title>Applicants Resources - NSF Graduate Research Fellowships Program (GRFP)</title>
title_en NSF Graduate Research Fellowships Program (GRFP)

Example 8:
If a hyphen is used in the text, we chop the title when we shouldn’t
https://www.nasa.gov/learning-resources/for-kids-and-students/what-is-pluto-grades-k-4/
<title>What Is Pluto? (Grades K-4) - NASA</title>
title_en: What Is Pluto? (Grades K
```


#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [x] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [x] You have specified at least one "Reviewer".
