### PR TITLE
Srch 6407 copy index

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,3 +9,4 @@ This folder contains miscellaneous scripts that help us perform reoccurring but 
 * `load_crawl_configs.py` - Helper to load crawl site JSON files to crawl config table.
 * `query_tester.py`       - Used to help acceptance test changes to the search query
 * `sitemaps_sandbox/`     - Included scripts to help in testing of sitemap functionality.
+* `transfer_docs.py`      - Transfer docs from elasticsearch to opensearch.

--- a/scripts/transfer_docs.py
+++ b/scripts/transfer_docs.py
@@ -3,8 +3,8 @@ import os
 from collections.abc import Generator
 
 import click
-from elasticsearch.helpers import scan
 from elasticsearch import NotFoundError
+from elasticsearch.helpers import scan
 from opensearchpy.exceptions import RequestError
 from opensearchpy.helpers import streaming_bulk
 from pythonjsonlogger.json import JsonFormatter
@@ -107,7 +107,7 @@ def validate_args(source: str | None, target: str | None) -> tuple[str, str]:
     Validate input args and assign defaults
     """
     if not source:
-        source = os.getenv("ELASTICSEARCH_SEARCHGOV_INDEX", "development-i14y-documents-searchgov-legacy")
+        source = os.getenv("LEGACY_OPENSEARCH_INDEX", "development-i14y-documents-searchgov-legacy")
     if not target:
         target = source
 

--- a/scripts/transfer_docs.py
+++ b/scripts/transfer_docs.py
@@ -1,0 +1,183 @@
+import logging
+import os
+from collections.abc import Generator
+
+import click
+
+from elasticsearch import NotFoundError
+from elasticsearch.helpers import scan
+from opensearchpy.exceptions import RequestError
+from opensearchpy.helpers import streaming_bulk
+from pythonjsonlogger.json import JsonFormatter
+
+from search_gov_crawler.search_engines.es_batch_upload import SearchGovElasticsearch
+from search_gov_crawler.search_engines.opensearch_batch_upload import SearchGovOpensearch
+from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
+
+logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
+logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+log = logging.getLogger("transfer_docs")
+
+
+def count_matching_documents(es: SearchGovElasticsearch, query: dict) -> int:
+    """
+    Return count of given query in elasticsearch index
+    """
+    response = es.client.count(index=es.index_name, body=query)
+    return response["count"]
+
+
+def get_matching_documents(es: SearchGovElasticsearch, query: dict, scroll: str) -> Generator[dict, None, None]:
+    """
+    Yield documents matching given query from elasticsearch index
+    """
+    yield from scan(es.client, index=es.index_name, query=query, scroll=scroll)
+
+
+def create_opensearch_action(document: dict, target_index: str) -> dict:
+    """
+    Create action dict in format needed for opensearch bulk upload
+    """
+    source = document["_source"]
+    return {"_index": target_index, "_id": source["id"], "_source": source}
+
+
+def transform_es_template(elasticseach_template: dict) -> dict:
+    """
+    Gets template from ES and modifies it so it can be applied in opensearch
+    """
+    index_patterns = elasticseach_template["index_patterns"]
+    settings = elasticseach_template["settings"]
+    mappings = elasticseach_template["mappings"]
+
+    return {"index_patterns": index_patterns, "template": {"settings": settings, "mappings": mappings}}
+
+
+def create_opensearch_target(sg_elastic: SearchGovElasticsearch, sg_opensearch: SearchGovOpensearch) -> None:
+    """Create opensearch target index and template"""
+
+    template_name = "documents"
+
+    try:
+        response = sg_elastic.client.indices.get_template(name=template_name)
+    except NotFoundError:
+        log.exception("%s template not found in Elasticsearch!", template_name)
+        raise
+
+    es_template = response.body.get(template_name)
+    os_template = transform_es_template(es_template)
+    sg_opensearch.client.indices.put_index_template(name=template_name, body=os_template)
+
+    try:
+        sg_opensearch.client.indices.create(index=sg_opensearch.index_name)
+    except RequestError:
+        log.exception("Index %s already exists, cannot create! Remove create-index flag!", sg_opensearch.index_name)
+        raise
+
+
+def generate_docs_from_elasticsearch(
+    sg_elastic: SearchGovElasticsearch,
+    target_index: str,
+    scroll: str,
+) -> Generator[dict]:
+    """
+    Get all documents from elasticsearch index.  This is a generator that yields one document at a time.
+    """
+    query = {"query": {"match_all": {}}}
+    expected_count = count_matching_documents(sg_elastic, query=query)
+
+    if not expected_count:
+        log.error("No documents found! Check query and try again!")
+        return
+
+    log.info("Found %s documents to transfer. Starting processing...", expected_count)
+
+    for elasticsearch_doc in get_matching_documents(sg_elastic, query=query, scroll=scroll):
+        doc_id = elasticsearch_doc.get("_id", "unknown")
+        try:
+            opensearch_action = create_opensearch_action(elasticsearch_doc, target_index)
+        except Exception:
+            log.exception("Error processing document %s", doc_id)
+            continue
+
+        yield opensearch_action
+
+
+def validate_args(source: str | None, target: str | None) -> tuple[str, str]:
+    """
+    Validate input args and assign defaults
+    """
+    if not source:
+        source = os.getenv("ELASTICSEARCH_SEARCHGOV_INDEX", "development-i14y-documents-searchgov-legacy")
+    if not target:
+        target = source
+
+    return source, target
+
+
+@click.group()
+def cli(): ...
+
+
+@cli.command()
+@click.argument("source", type=str, default=None)
+@click.argument("target", type=str, default=None)
+@click.option(
+    "--create-target",
+    "-ct",
+    is_flag=True,
+    default=False,
+    required=True,
+    help="Create target index based on source index.",
+)
+@click.option("--scroll", type=str, default="60m", help="Length elasticsearch keeps scroll window open.")
+def copy_index(source: str, target: str | None, create_target, scroll):
+    """
+    Transfer docs from i14y index in elasticsearch to opensearch
+    """
+    source, target = validate_args(source, target)
+    sg_es = SearchGovElasticsearch(es_index=source)
+    sg_os = SearchGovOpensearch(opensearch_index=target)
+
+    try:
+        sg_es.client.indices.exists(index=source)
+    except Exception:
+        log.exception("Source index %s does not exist in Elasticsearch!", source)
+        raise
+
+    if create_target:
+        log.info("Creating target template and index...")
+        create_opensearch_target(sg_es, sg_os)
+
+    if not sg_os.client.indices.exists(index=sg_os.index_name):
+        log.error("Index %s does not exist in Opensearch!", sg_os.index_name)
+        raise
+
+    results = {"succeeded": [], "failed": []}
+    chunk_size = 100
+    for actions, (success, item) in enumerate(
+        streaming_bulk(
+            sg_os.client,
+            actions=generate_docs_from_elasticsearch(sg_es, sg_os.index_name, scroll),
+            chunk_size=chunk_size,
+        ),
+    ):
+        if success:
+            results["succeeded"].append(item)
+        else:
+            results["failed"].append(item)
+            log.error("Error loading batch of documents into Opensearch!")
+
+        if (actions + 1) % chunk_size == 0 and actions > 0:
+            log.error("Ingested documents into Opensearch! Total Ingested: %s", len(results["succeeded"]))
+
+    log.info("Finished loading documents!")
+    log.info("Bulk-inserted %s documents to Opensearch index %s.", len(results["succeeded"]), sg_os.index_name)
+    if results["failed"]:
+        log.info("There were %s errors:", len(results["failed"]))
+        for item in results["failed"]:
+            log.error(item["index"]["error"])
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/transfer_docs.py
+++ b/scripts/transfer_docs.py
@@ -3,9 +3,8 @@ import os
 from collections.abc import Generator
 
 import click
-
-from elasticsearch import NotFoundError
 from elasticsearch.helpers import scan
+from elasticsearch import NotFoundError
 from opensearchpy.exceptions import RequestError
 from opensearchpy.helpers import streaming_bulk
 from pythonjsonlogger.json import JsonFormatter
@@ -139,11 +138,9 @@ def copy_index(source: str, target: str | None, create_target, scroll):
     sg_es = SearchGovElasticsearch(es_index=source)
     sg_os = SearchGovOpensearch(opensearch_index=target)
 
-    try:
-        sg_es.client.indices.exists(index=source)
-    except Exception:
+    if not sg_es.client.indices.exists(index=source):
         log.exception("Source index %s does not exist in Elasticsearch!", source)
-        raise
+        raise Exception("Source Index Doesn't Exist!")
 
     if create_target:
         log.info("Creating target template and index...")
@@ -151,7 +148,7 @@ def copy_index(source: str, target: str | None, create_target, scroll):
 
     if not sg_os.client.indices.exists(index=sg_os.index_name):
         log.error("Index %s does not exist in Opensearch!", sg_os.index_name)
-        raise
+        raise RequestError(404, "Index does not exist!")
 
     results = {"succeeded": [], "failed": []}
     chunk_size = 100
@@ -169,7 +166,7 @@ def copy_index(source: str, target: str | None, create_target, scroll):
             log.error("Error loading batch of documents into Opensearch!")
 
         if (actions + 1) % chunk_size == 0 and actions > 0:
-            log.error("Ingested documents into Opensearch! Total Ingested: %s", len(results["succeeded"]))
+            log.info("Ingested documents into Opensearch! Total Ingested: %s", len(results["succeeded"]))
 
     log.info("Finished loading documents!")
     log.info("Bulk-inserted %s documents to Opensearch index %s.", len(results["succeeded"]), sg_os.index_name)

--- a/tests/scripts/test_transfer_docs.py
+++ b/tests/scripts/test_transfer_docs.py
@@ -1,0 +1,247 @@
+import pytest
+from click.testing import CliRunner
+from elastic_transport import ApiResponseMeta
+from elasticsearch import NotFoundError
+from opensearchpy.exceptions import RequestError
+
+from scripts import transfer_docs as td
+
+
+def test_count_matching_documents(mocker):
+    mock_sg_elastic = mocker.MagicMock()
+    mock_sg_elastic.client.count.return_value = {"count": 100}
+
+    count = td.count_matching_documents(es=mock_sg_elastic, query={"some": "query"})
+    assert count == 100
+
+
+def test_get_matching_documents(mocker):
+    mock_sg_elastic = mocker.MagicMock()
+
+    mock_scan = mocker.patch("scripts.transfer_docs.scan")
+    mock_scan.return_value = [
+        {"_id": "1", "_source": {"field": "value1"}},
+        {"_id": "2", "_source": {"field": "value2"}},
+    ]
+
+    documents = list(td.get_matching_documents(es=mock_sg_elastic, query={"some": "query"}, scroll="1m"))
+    assert len(documents) == 2
+    assert documents[0]["_id"] == "1"
+    assert documents[0]["_source"]["field"] == "value1"
+    assert documents[1]["_id"] == "2"
+    assert documents[1]["_source"]["field"] == "value2"
+
+
+def test_create_opensearch_action():
+    document = {
+        "_id": "asdf",
+        "_source": {
+            "id": "1234",
+            "data": "value",
+        },
+        "_index": "test-source-index",
+    }
+    index = "test-target-index"
+
+    action = td.create_opensearch_action(document=document, target_index=index)
+    assert action == {
+        "_index": "test-target-index",
+        "_id": "1234",
+        "_source": {
+            "id": "1234",
+            "data": "value",
+        },
+    }
+
+
+def test_transform_es_template():
+    es_template = {
+        "index_patterns": ["*test*"],
+        "settings": {"setting 1": "value 1"},
+        "mappings": {"field": "mapping value"},
+    }
+    os_template = td.transform_es_template(es_template)
+
+    assert os_template == {
+        "index_patterns": ["*test*"],
+        "template": {"settings": {"setting 1": "value 1"}, "mappings": {"field": "mapping value"}},
+    }
+
+
+def test_create_opensearch_target(mocker):
+    mock_es = mocker.MagicMock()
+    mock_os = mocker.MagicMock()
+
+    mocker.patch("scripts.transfer_docs.transform_es_template")
+
+    mock_get_template = mock_es.client.indices.get_template
+    mock_put_template = mock_os.client.indices.put_index_template
+    mock_create = mock_os.client.indices.create
+
+    td.create_opensearch_target(mock_es, mock_os)
+
+    mock_get_template.assert_called_once()
+    mock_put_template.assert_called_once()
+    mock_create.assert_called_once()
+
+
+def test_create_opensearch_target_index_not_found(mocker):
+    mock_es = mocker.MagicMock()
+    mock_os = mocker.MagicMock()
+
+    meta = mocker.Mock(spec=ApiResponseMeta)
+    meta.status = 404
+    body = {"error": "Not Found", "status": 404}
+
+    mock_es.client.indices.get_template.side_effect = [
+        NotFoundError(message="Document not found", meta=meta, body=body)
+    ]
+
+    with pytest.raises(NotFoundError, match="Document not found"):
+        td.create_opensearch_target(mock_es, mock_os)
+
+
+def test_create_opensearch_target_index_already_exists(mocker):
+    mock_es = mocker.MagicMock()
+    mock_os = mocker.MagicMock()
+    mock_os.client.indices.create.side_effect = [RequestError(400, "Index already exists!")]
+
+    with pytest.raises(RequestError, match="Index already exists!"):
+        td.create_opensearch_target(mock_es, mock_os)
+
+
+def test_generate_docs_from_elasticsearch(mocker):
+    mock_es = mocker.MagicMock()
+
+    test_docs = [
+        {"_id": "123", "_source": {"data": "here"}},
+        {"_id": "456", "_source": {"data": "here"}},
+    ]
+
+    mock_count_docs = mocker.patch("scripts.transfer_docs.count_matching_documents")
+    mock_count_docs.return_value = 2
+
+    mocker.patch("scripts.transfer_docs.get_matching_documents", return_value=test_docs)
+    mocker.patch("scripts.transfer_docs.create_opensearch_action", return_value=test_docs)
+
+    output = list(td.generate_docs_from_elasticsearch(mock_es, "test-index", "10m"))
+    assert len(output) == len(test_docs)
+
+
+def test_generate_docs_from_elasticsearch_no_docs(mocker, caplog):
+    mock_es = mocker.MagicMock()
+
+    mock_count_docs = mocker.patch("scripts.transfer_docs.count_matching_documents")
+    mock_count_docs.return_value = 0
+
+    with caplog.at_level("INFO"):
+        output = list(td.generate_docs_from_elasticsearch(mock_es, "test-index", "10m"))
+
+    assert not output
+    assert "No documents found! Check query and try again!" in caplog.messages
+
+
+def test_generate_docs_from_elasticsearch_doc_error(mocker, caplog):
+    mock_es = mocker.MagicMock()
+
+    test_docs = [
+        {"_id": "123", "_source": {"data": "here"}},
+        {"_id": "456", "_source": {"data": "here"}},
+    ]
+
+    mock_count_docs = mocker.patch("scripts.transfer_docs.count_matching_documents")
+    mock_count_docs.return_value = 2
+
+    mocker.patch("scripts.transfer_docs.get_matching_documents", return_value=test_docs)
+    mocker.patch(
+        "scripts.transfer_docs.create_opensearch_action",
+        side_effect=[Exception("Error here!"), Exception("Error here!")],
+    )
+
+    with caplog.at_level("INFO"):
+        output = list(td.generate_docs_from_elasticsearch(mock_es, "test-index", "10m"))
+
+    assert not output
+    assert all(
+        message in caplog.messages for message in ["Error processing document 123", "Error processing document 456"]
+    )
+
+
+VALIDATE_ARGS_TEST_CASES = [
+    (None, None, ("development-i14y-documents-searchgov-legacy", "development-i14y-documents-searchgov-legacy")),
+    ("test1", None, ("test1", "test1")),
+    ("test1", "test2", ("test1", "test2")),
+]
+
+
+@pytest.mark.parametrize(("source", "target", "output"), VALIDATE_ARGS_TEST_CASES)
+def test_validate_args(monkeypatch, source, target, output):
+    monkeypatch.delenv("ELASTICSEARCH_SEARCHGOV_INDEX", raising=False)
+    assert output == td.validate_args(source, target)
+
+
+def test_validate_args_env(monkeypatch):
+    monkeypatch.setenv("ELASTICSEARCH_SEARCHGOV_INDEX", "test-env")
+    assert td.validate_args(None, None) == ("test-env", "test-env")
+
+
+@pytest.mark.parametrize(
+    ("args", "log_msgs"),
+    [
+        ([], ["Finished loading documents!", "There were 100 errors:", "Whoops!"]),
+        (
+            ["--create-target"],
+            [
+                "Finished loading documents!",
+                "There were 100 errors:",
+                "Whoops!",
+                "Creating target template and index...",
+            ],
+        ),
+    ],
+)
+def test_copy_index(mocker, caplog, args, log_msgs):
+    mocker.patch("scripts.transfer_docs.create_opensearch_target")
+    mocker.patch("scripts.transfer_docs.validate_args", return_value=("source", "target"))
+    mocker.patch("scripts.transfer_docs.SearchGovElasticsearch")
+    mock_os = mocker.patch("scripts.transfer_docs.SearchGovOpensearch")
+    mock_os.sg_os.client.indices.exists.return_value = True
+
+    mock_streaming_bulk = mocker.patch("scripts.transfer_docs.streaming_bulk")
+    mock_streaming_bulk.return_value = [
+        (True, {"result": "Success"}),
+        (True, {"result": "Success"}),
+        (False, {"index": {"error": "Whoops!"}}),
+        (True, {"result": "Success"}),
+        (True, {"result": "Success"}),
+    ] * 100
+    runner = CliRunner()
+    with caplog.at_level("INFO"):
+        runner.invoke(td.copy_index, args)
+
+    assert all(message in caplog.messages for message in log_msgs)
+
+
+def test_copy_index_no_source_index(mocker):
+    mock_es = mocker.patch("scripts.transfer_docs.SearchGovElasticsearch")
+    mock_es.return_value.client.indices.exists.return_value = False
+    mocker.patch("scripts.transfer_docs.SearchGovOpensearch")
+
+    runner = CliRunner()
+    result = runner.invoke(td.copy_index)
+    assert result.exception is not None
+    assert isinstance(result.exception, Exception)
+    assert str(result.exception) == "Source Index Doesn't Exist!"
+
+
+def test_copy_no_target_index(mocker):
+    mocker.patch("scripts.transfer_docs.SearchGovElasticsearch")
+    mock_os = mocker.patch("scripts.transfer_docs.SearchGovOpensearch")
+    mock_os.return_value.client.indices.exists.return_value = False
+    # mock_os.client.indices.exists.return_value = False
+
+    runner = CliRunner()
+    result = runner.invoke(td.copy_index)
+    assert result.exception is not None
+    assert isinstance(result.exception, RequestError)
+    assert "Index does not exist!" in str(result.exception)

--- a/tests/scripts/test_transfer_docs.py
+++ b/tests/scripts/test_transfer_docs.py
@@ -176,12 +176,12 @@ VALIDATE_ARGS_TEST_CASES = [
 
 @pytest.mark.parametrize(("source", "target", "output"), VALIDATE_ARGS_TEST_CASES)
 def test_validate_args(monkeypatch, source, target, output):
-    monkeypatch.delenv("ELASTICSEARCH_SEARCHGOV_INDEX", raising=False)
+    monkeypatch.delenv("LEGACY_OPENSEARCH_INDEX", raising=False)
     assert output == td.validate_args(source, target)
 
 
 def test_validate_args_env(monkeypatch):
-    monkeypatch.setenv("ELASTICSEARCH_SEARCHGOV_INDEX", "test-env")
+    monkeypatch.setenv("LEGACY_OPENSEARCH_INDEX", "test-env")
     assert td.validate_args(None, None) == ("test-env", "test-env")
 
 
@@ -238,7 +238,6 @@ def test_copy_no_target_index(mocker):
     mocker.patch("scripts.transfer_docs.SearchGovElasticsearch")
     mock_os = mocker.patch("scripts.transfer_docs.SearchGovOpensearch")
     mock_os.return_value.client.indices.exists.return_value = False
-    # mock_os.client.indices.exists.return_value = False
 
     runner = CliRunner()
     result = runner.invoke(td.copy_index)


### PR DESCRIPTION
## Summary
- The goal of this change is to add a script that is able to copy docs from elasticsearch to opensearch to support switching the app to using opensearch.
- Supports
  * Named source and target indices
  * Using `LEGACY_OPENSEARCH_INDEX` env var
  * Creating a target for testing
  * Re-running to update docs if needed

### Usage
The help option command gives you guidance on how to use it, first showing commands and then in more detail on the `copy-index` command:
```bash
$> python scripts/transfer_docs.py --help
Usage: transfer_docs.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  copy-index  Transfer docs from i14y index in elasticsearch to opensearch
```

```
$> python scripts/transfer_docs.py copy-index --help
Usage: transfer_docs.py copy-index [OPTIONS] [SOURCE] [TARGET]

  Transfer docs from i14y index in elasticsearch to opensearch

Options:
  -ct, --create-target  Create target index based on source index.  [required]
  --scroll TEXT         Length elasticsearch keeps scroll window open.
  --help                Show this message and exit.
```


### Testing
#### Prerequisites
* Start search services, from search-services root run
```
docker compose up
```
* Clone i14y project then
```
touch config/secrets.yml
```
* run i14y in search-services
```
docker compose up i14y
```
#### Create Legacy ES Index
* In searchgov project root,
  * Edit `.env.development`, change `I14Y_HOST` to have port `3200`
  * Enter rails console and create i14y index
```
bin/docker bin/rails console
I14yDrawer.create(handle: 'searchgov_legacy', description: 'searchgov legacy')
```
* Verify index creation and mappings applied in ES/Kibana, and contains 0 docs
```
GET /development-i14y-documents-searchgov_legacy-v1/_mappings
GET /development-i14y-documents-searchgov_legacy-v1/_count
```
 
#### Load data into legacy index
* In [this gist](https://gist.github.com/selfdanielj/e3ff7ec4af1d43d78955bf1e8d533d14) are two files, a json file consisting of 100 searchgov records and a python script to load them, put them both in the spider project root, If you used the commands above, nothing to change but if you used a different handle change the `INDEX_NAME` value on line 14 if the python script.
```
source venv/bin/activate
python transfer_docs_loader.py 
```
* Verify 100 records added to your ES index.
```
GET /development-i14y-documents-searchgov_legacy-v1/_count
```

#### Copy index and verify results
* Run transfer_docs script to copy records from ES index to opensearch index of the same name, create the target in opensearch since we don't have that capability in searchgov yet.
```
python scripts/transfer_docs.py copy-index development-i14y-documents-searchgov_legacy-v1 --create-target
```
* In opensearch/dashboards, verify existence of index and count of docs
```
GET /development-i14y-documents-searchgov_legacy-v1/_mappings
GET /development-i14y-documents-searchgov_legacy-v1/_count
```

#### Optional Additional Testing
* Try running the script with different options:
  * Now that the index exists, run again with out the create-target option, should overwrite the 100 records
  * Try copying the data to another opensearch index by passing a target index name to the command along with the create-target flag.
  * Add a doc to the ES index and rerun, see if the new doc comes over and total is 101 docs
  * Delete a doc from the Opensearch index and rerun to see if the 100 docs are again present

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [X] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [X] You have specified at least one "Reviewer".
