### PR TITLE
SRCH-6407 allow source docs with id value in source

### DIFF
--- a/scripts/transfer_docs.py
+++ b/scripts/transfer_docs.py
@@ -38,7 +38,7 @@ def create_opensearch_action(document: dict, target_index: str) -> dict:
     Create action dict in format needed for opensearch bulk upload
     """
     source = document["_source"]
-    return {"_index": target_index, "_id": source["id"], "_source": source}
+    return {"_index": target_index, "_id": document["_id"], "_source": source}
 
 
 def transform_es_template(elasticseach_template: dict) -> dict:

--- a/tests/scripts/test_transfer_docs.py
+++ b/tests/scripts/test_transfer_docs.py
@@ -32,26 +32,23 @@ def test_get_matching_documents(mocker):
     assert documents[1]["_source"]["field"] == "value2"
 
 
-def test_create_opensearch_action():
-    document = {
-        "_id": "asdf",
-        "_source": {
-            "id": "1234",
-            "data": "value",
-        },
-        "_index": "test-source-index",
-    }
+CREATE_ACTION_TEST_CASES = [
+    (
+        {"_id": "1234", "_source": {"id": "1234", "data": "value"}, "_index": "test-source-index"},
+        {"_index": "test-target-index", "_id": "1234", "_source": {"id": "1234", "data": "value"}},
+    ),
+    (
+        {"_id": "1234", "_source": {"data": "value"}, "_index": "test-source-index"},
+        {"_index": "test-target-index", "_id": "1234", "_source": {"data": "value"}},
+    ),
+]
+
+
+@pytest.mark.parametrize(("document", "action"), CREATE_ACTION_TEST_CASES)
+def test_create_opensearch_action(document, action):
     index = "test-target-index"
 
-    action = td.create_opensearch_action(document=document, target_index=index)
-    assert action == {
-        "_index": "test-target-index",
-        "_id": "1234",
-        "_source": {
-            "id": "1234",
-            "data": "value",
-        },
-    }
+    assert action == td.create_opensearch_action(document=document, target_index=index)
 
 
 def test_transform_es_template():


### PR DESCRIPTION
## Summary
Some docs in elasticsearch prod, e.g. `GET /production-i14y-documents-searchgov-v6/_doc/810d36989bf8515d1d470e4fafe4fcac502708cc7721e587baaf8ac3784bd461` do not have an `id` field in their `_source`.  This was unexpected and not noticed in other testing.
- This change removes reliance on values in the `_source` and instead gets it from the response object root, which always exists.
- Added unit tests to ensure we support documents with and without `id` values in the `_source`
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [X] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [X] You have specified at least one "Reviewer".
