### PR TITLE
Quick change to address Github Action Alert

### DIFF
--- a/.github/workflows/scanning-service.yml
+++ b/.github/workflows/scanning-service.yml
@@ -1,5 +1,7 @@
 name: GSA-TTS Scanning Service
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   lint:
     uses: GSA-TTS/scanning-service/.github/workflows/dependency-lint.yml@main


### PR DESCRIPTION
During PRs, would see messages like below.  This change implements suggested fix.
<img width="999" height="776" alt="image" src="https://github.com/user-attachments/assets/0026de15-a052-4893-a9a8-a4973e9f4cdd" />

