### PR TITLE
SRCH-6336 Remove port from spidered domains

### DIFF
--- a/search_gov_crawler/search_gov_spiders/middlewares.py
+++ b/search_gov_crawler/search_gov_spiders/middlewares.py
@@ -65,8 +65,7 @@ class SearchGovSpidersSpiderMiddleware(SearchgovMiddlewareBase):
 
     def _remove_port_from_url(self, url: ParseResult) -> str:
         """Private helper function to remove port from url"""
-        netloc_without_port = url.netloc.split(":")[0]
-        url_without_port = url._replace(netloc=netloc_without_port)
+        url_without_port = url._replace(netloc=url.hostname)
         return url_without_port.geturl()
 
     def process_spider_input(self, response: Response) -> None:  # noqa: ARG002

--- a/search_gov_crawler/search_gov_spiders/middlewares.py
+++ b/search_gov_crawler/search_gov_spiders/middlewares.py
@@ -8,7 +8,7 @@ import re
 import warnings
 from collections.abc import Iterator
 from typing import Any, Self
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from scrapy import signals
 from scrapy.crawler import Crawler
@@ -55,14 +55,19 @@ class SearchGovSpidersSpiderMiddleware(SearchgovMiddlewareBase):
 
         return False
 
-    def _remove_url_jsession_id(self, url: str | None) -> str | None:
+    def _remove_url_jsession_id(self, url: ParseResult) -> str:
         """Private helper function to filter urls by existence of JSESSIONID (if applicable)"""
 
-        parse_result = urlparse(url)
-        if "jsessionid" in parse_result.params.lower():
-            url = parse_result._replace(params="").geturl()
+        if "jsessionid" in url.params.lower():
+            url = url._replace(params="")
 
-        return url
+        return url.geturl()
+
+    def _remove_port_from_url(self, url: ParseResult) -> str:
+        """Private helper function to remove port from url"""
+        netloc_without_port = url.netloc.split(":")[0]
+        url_without_port = url._replace(netloc=netloc_without_port)
+        return url_without_port.geturl()
 
     def process_spider_input(self, response: Response) -> None:  # noqa: ARG002
         """
@@ -117,8 +122,12 @@ class SearchGovSpidersSpiderMiddleware(SearchgovMiddlewareBase):
         if self._filter_url_query_string(url=request.url):
             return None
 
-        if "jsessionid" in request.url.lower():
-            request = request.replace(url=self._remove_url_jsession_id(url=request.url))
+        parsed_url = urlparse(request.url)
+        if "jsessionid" in parsed_url.geturl().lower():
+            request = request.replace(url=self._remove_url_jsession_id(url=parsed_url))
+
+        if parsed_url.port:
+            request = request.replace(url=self._remove_port_from_url(url=parsed_url))
 
         return request
 
@@ -148,8 +157,12 @@ class SearchGovSpidersSpiderMiddleware(SearchgovMiddlewareBase):
         if self._filter_url_query_string(url=item_url):
             return None
 
-        if "jsessionid" in item_url.lower():
-            item["url"] = self._remove_url_jsession_id(url=item_url)
+        parsed_url = urlparse(item["url"])
+        if "jsessionid" in parsed_url.geturl().lower():
+            item["url"] = self._remove_url_jsession_id(url=parsed_url)
+
+        if parsed_url.port:
+            item["url"] = self._remove_port_from_url(url=parsed_url)
 
         return item
 

--- a/tests/search_gov_crawler/search_gov_spiders/test_middlewares.py
+++ b/tests/search_gov_crawler/search_gov_spiders/test_middlewares.py
@@ -162,20 +162,44 @@ def test_spider_middleware_allow_query_string_request(test_crawler, dont_filter,
     assert getattr(operator, none_test)(mw.get_processed_request(request=request, response=None), None)
 
 
-@pytest.mark.parametrize(
-    ("url_in", "url_out"),
-    [
-        ("https://www.example.com/test", "https://www.example.com/test"),
-        ("http://www.example.com/test;jsessionid=12345", "http://www.example.com/test"),
-        ("http://www.example.com/test;JSESSIONID=12345", "http://www.example.com/test"),
-        (
-            "https://www.example.com/test/1/more;jsessionid=67890",
-            "https://www.example.com/test/1/more",
-        ),
-        ("http://www.example.com/test;jsessionid=12345?query=string", "http://www.example.com/test?query=string"),
-    ],
-)
+JSESSIONID_REMOVAL_TEST_CASES = [
+    ("https://www.example.com/test", "https://www.example.com/test"),
+    ("http://www.example.com/test;jsessionid=12345", "http://www.example.com/test"),
+    ("http://www.example.com/test;JSESSIONID=12345", "http://www.example.com/test"),
+    (
+        "https://www.example.com/test/1/more;jsessionid=67890",
+        "https://www.example.com/test/1/more",
+    ),
+    ("http://www.example.com/test;jsessionid=12345?query=string", "http://www.example.com/test?query=string"),
+]
+
+
+@pytest.mark.parametrize(("url_in", "url_out"), JSESSIONID_REMOVAL_TEST_CASES)
 def test_spider_middleware_jsessionid_removal_request(test_crawler, url_in, url_out):
+    test_crawler.spider = Spider.from_crawler(
+        crawler=test_crawler,
+        name="test",
+        allow_query_string=True,
+        allowed_domains="example.com",
+    )
+    mw = SearchGovSpidersSpiderMiddleware.from_crawler(test_crawler)
+    request = Request(url_in)
+    processed_request = mw.get_processed_request(request=request, response=None)
+    assert processed_request.url == url_out
+
+
+URL_PORT_REMOVAL_TEST_CASES = [
+    ("https://www.example.com:8080/test", "https://www.example.com/test"),
+    ("https://www.example.com:8080/test/test/test.html", "https://www.example.com/test/test/test.html"),
+    ("https://www.example.com:8080/test/test/test.pdf", "https://www.example.com/test/test/test.pdf"),
+    ("https://www.example.com:8080/", "https://www.example.com/"),
+    ("https://www.example.com:8080", "https://www.example.com"),
+    ("https://www.example.com:443", "https://www.example.com"),
+]
+
+
+@pytest.mark.parametrize(("url_in", "url_out"), URL_PORT_REMOVAL_TEST_CASES)
+def test_spider_middleware_port_removal_request(test_crawler, url_in, url_out):
     test_crawler.spider = Spider.from_crawler(
         crawler=test_crawler,
         name="test",
@@ -210,20 +234,23 @@ def test_spider_middleware_allow_query_string_item(test_crawler, dont_filter, al
     assert getattr(operator, none_test)(mw.get_processed_item(item, response), None)
 
 
-@pytest.mark.parametrize(
-    ("url_in", "url_out"),
-    [
-        ("https://www.example.com/test", "https://www.example.com/test"),
-        ("http://www.example.com/test;jsessionid=12345", "http://www.example.com/test"),
-        ("http://www.example.com/test;JSESSIONID=12345", "http://www.example.com/test"),
-        (
-            "https://www.example.com/test/1/more;jsessionid=67890",
-            "https://www.example.com/test/1/more",
-        ),
-        ("http://www.example.com/test;jsessionid=12345?query=string", "http://www.example.com/test?query=string"),
-    ],
-)
+@pytest.mark.parametrize(("url_in", "url_out"), JSESSIONID_REMOVAL_TEST_CASES)
 def test_spider_middleware_jsessionid_removal_item(test_crawler, url_in, url_out):
+    test_crawler.spider = Spider.from_crawler(
+        crawler=test_crawler,
+        name="test",
+        allow_query_string=True,
+        allowed_domains="example.com",
+    )
+    mw = SearchGovSpidersSpiderMiddleware.from_crawler(test_crawler)
+    item = SearchGovSpidersItem(url=url_in)
+    response = Response(url=url_in, status=200, request=Request(url_in))
+
+    assert mw.get_processed_item(item, response).get("url") == url_out
+
+
+@pytest.mark.parametrize(("url_in", "url_out"), URL_PORT_REMOVAL_TEST_CASES)
+def test_spider_middleware_port_removal_item(test_crawler, url_in, url_out):
     test_crawler.spider = Spider.from_crawler(
         crawler=test_crawler,
         name="test",


### PR DESCRIPTION
## Summary
- Plugs into existing spider middleware to remove port from domains of requests and items.  This strategy mimics what was done to remove `JSESSIONID` from URLs.  This causes duplication and fragmentation of counts during analysis.
- Updated unit tests to cover these changes.

### Testing
- Prep
  - Ensure opensearch and redis running as part of `search-services`
  - Ensure spider index exists
    - if not use rake task in [searchgov project](https://github.com/GSA/search-gov#opensearch-migration): `$ rake opensearch:create_index`
    - this index is referred to as `development-i14y-documents-searchgov` below
  - Ensure no documents in test domain
     ```
     POST /development-i14y-documents-searchgov/_delete_by_query
     {
       "query": {
         "bool": {
           "should": [
             {
               "term": { "domain_name": { "value": "www.nwcg.gov:443" } }
             },
             {
                "term": { "domain_name": { "value": "www.nwcg.gov" } }
             }
           ],
           "minimum_should_match": 1
         }
       }
     }
     ```
  - Query to verify counts (should initially be 0s)
       ```
       GET /development-i14y-documents-searchgov/_search
       {
         "size":0,
         "query": {
           "bool": {
             "should": [
               {
                 "term": { "domain_name": { "value": "www.nwcg.gov:443" } }
               },
               {
                  "term": { "domain_name": { "value": "www.nwcg.gov" } }
               }
             ],
             "minimum_should_match": 1
           }
         },
         "aggs": {
           "domains": {
             "terms": {
               "field": "domain_name.keyword",
               "size": 5
             }
           }
         }
       }
       ```
  - Command to run to start test crawl
    - if you haven't built the project before, first run `make docker-build` otherwise just run this command: 
    ```
    make docker-scrapy-crawl ARGS="domain_spider -a allowed_domains=www.nwcg.gov -a start_urls='https://www.nwcg.gov:443/member-view/doi-bureau-of-land-management/keating/molly' -a output_target=opensearch -a depth_limit=1"
    ``` 
- Process to Test 
  - With `main` checked out
    - Run above `make` command
    - You should eventually see docs from the target domain **with and without** the port, something like
      ```
      {
        ...
        "aggregations": {
          "domains": {
            "doc_count_error_upper_bound": 0,
            "sum_other_doc_count": 0,
            "buckets": [
              {
                "key": "www.nwcg.gov:443",
                "doc_count": 371
              },
              {
                "key": "www.nwcg.gov",
                "doc_count": 6
              }
            ]
          }
        }
      }
      ```
    - You can kill the spider process whenever you see enough data
    - Run delete by query command above to clear out data
  - With `SRCH-6336_remove_port_from_urls` checked out
    - Run above `make` command
    - You should see all documents from the target domain in a single domain **without the port**, something like
       ```
       {
        ...
        "aggregations": {
          "domains": {
            "doc_count_error_upper_bound": 0,
            "sum_other_doc_count": 0,
            "buckets": [
              {
                "key": "www.nwcg.gov",
                "doc_count": 400
              }
            ]
          }
        }
      }
      ```
    - You can kill the spider process whenever you see enough data

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [X] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [x] You have specified at least one "Reviewer".
