### PR TITLE
SRCH-6634 Re-enable freshness spider and set daily "8 days old" scheduled check

### DIFF
--- a/cicd-scripts/app_start.sh
+++ b/cicd-scripts/app_start.sh
@@ -44,8 +44,7 @@ nohup bash -lc "source ~/.profile && $VENV_PYTHON ./$DAP_SCRIPT" >> "$LOG_FILE" 
 nohup bash -lc "source ~/.profile && $VENV_PYTHON ./$SCHEDULER_SCRIPT" >> "$LOG_FILE" 2>&1 &
 
 # start freshness cheker
-# SRCH-6633 disabled so we can manually run and delete documents
-# nohup bash -c "source ./venv/bin/activate && ./venv/bin/python ./$FRESHNESS_SCRIPT" >> $LOG_FILE 2>&1 &
+nohup bash -c "source ./venv/bin/activate && ./venv/bin/python ./$FRESHNESS_SCRIPT" >> $LOG_FILE 2>&1 &
 
 # check that scheduler is running before exit, it not raise error
 sleep 5

--- a/cicd-scripts/app_stop.sh
+++ b/cicd-scripts/app_stop.sh
@@ -151,8 +151,7 @@ remove_venv
 purge_pip_cache
 
 # Stop freshness checker
-# SRCH-6633 disabled so we can manually run and delete documents
-# stop_freshness_checker
+stop_freshness_checker
 
 # Stop scrapy scheduler if running
 stop_scrapy_scheduler

--- a/search_gov_crawler/config/freshness/freshness-checker-production.json
+++ b/search_gov_crawler/config/freshness/freshness-checker-production.json
@@ -1,8 +1,8 @@
 [
     {
-        "name": "documents-older-than-ten-days",
+        "name": "documents-eight-days-old",
         "schedule": "0 22 * * *",
-        "query": {"query": { "range": { "updated_at": { "lte": "now-10d/d" }}}},
+        "query": { "query": { "range": { "updated_at": { "gte": "now-8d/d", "lt": "now-7d/d" }}}},
         "max_results": null
     }
 ]

--- a/search_gov_crawler/config/freshness/freshness-checker-production.json
+++ b/search_gov_crawler/config/freshness/freshness-checker-production.json
@@ -2,7 +2,7 @@
     {
         "name": "documents-eight-days-old",
         "schedule": "0 22 * * *",
-        "query": { "query": { "range": { "updated_at": { "gte": "now-8d/d", "lt": "now-7d/d" }}}},
+        "query": {"query": { "range": { "updated_at": { "gte": "now-8d/d", "lt": "now-7d/d" }}}},
         "max_results": null
     }
 ]


### PR DESCRIPTION
## Summary
- After manual runs in SRCH-6634 we are ready to re-enable this process.
- The change is that in production we now want to have this checking docs that are 8 days old for freshness since we have already checked all older docs.  In the future we will likely add less frequent jobs to check older docs.

### Testing
- Verify changes are as expected, no functionality changes.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [X] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

- [X] You have provided testing instructions to help reviewers verify the changes made within the PR

#### Process Checks

- [x] You have specified at least one "Reviewer".
